### PR TITLE
Improve static table lookup performance by indexing all name occurances

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/QpackStaticTable.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackStaticTable.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.http3;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 
 import io.netty.handler.codec.UnsupportedValueConverter;
@@ -144,7 +145,7 @@ final class QpackStaticTable {
      */
     static final int length = STATIC_TABLE.size();
 
-    private static final CharSequenceMap<Integer> STATIC_INDEX_BY_NAME = createMap(length);
+    private static final CharSequenceMap<List<Integer>> STATIC_INDEX_BY_NAME = createMap(length);
 
     private static QpackHeaderField newEmptyHeaderField(String name) {
         return new QpackHeaderField(AsciiString.cached(name), AsciiString.EMPTY_STRING);
@@ -167,11 +168,12 @@ final class QpackStaticTable {
      * table. Returns -1 if the header field name is not in the static table.
      */
     static int getIndex(CharSequence name) {
-        Integer index = STATIC_INDEX_BY_NAME.get(name);
+        List<Integer> index = STATIC_INDEX_BY_NAME.get(name);
         if (index == null) {
             return NOT_FOUND;
         }
-        return index;
+
+        return index.get(0);
     }
 
     /**
@@ -181,39 +183,44 @@ final class QpackStaticTable {
      *    c) -1 if name was not found in the static table.
      */
     static int findFieldIndex(CharSequence name, CharSequence value) {
-        int nameIndex = getIndex(name);
+        final List<Integer> nameIndex = STATIC_INDEX_BY_NAME.get(name);
 
         // Early return if name not found in the table.
-        if (nameIndex == NOT_FOUND) {
+        if (nameIndex == null) {
             return NOT_FOUND;
         }
 
         // If name was found, check all subsequence elements of the table for exact match.
-        int index = nameIndex;
-        while (index < length) {
-            QpackHeaderField field = getField(index);
-            if (QpackUtil.equalsVariableTime(name, field.name) && QpackUtil.equalsVariableTime(value, field.value)) {
+        for (int index: nameIndex) {
+            QpackHeaderField field = STATIC_TABLE.get(index);
+            if (QpackUtil.equalsVariableTime(value, field.value)) {
                 return index;
             }
-            index++;
         }
 
         // No exact match was found but we still can reference the name.
-        return nameIndex | MASK_NAME_REF;
+        return nameIndex.get(0) | MASK_NAME_REF;
     }
 
     /**
      * Creates a map CharSequenceMap header name to index value to allow quick lookup.
      */
     @SuppressWarnings("unchecked")
-    private static CharSequenceMap<Integer> createMap(int length) {
-        CharSequenceMap<Integer> mapping =
-            new CharSequenceMap<Integer>(true, UnsupportedValueConverter.<Integer>instance(), length);
+    private static CharSequenceMap<List<Integer>> createMap(int length) {
+        CharSequenceMap<List<Integer>> mapping =
+            new CharSequenceMap<List<Integer>>(true, UnsupportedValueConverter.<List<Integer>>instance(), length);
         // Iterate through the static table in reverse order to
         // save the smallest index for a given name in the map.
-        for (int index = length - 1; index >= 0; index--) {
-            QpackHeaderField field = getField(index);
-            mapping.set(field.name, index);
+        for (int index = 0; index < length; index++) {
+            final QpackHeaderField field = getField(index);
+            final List<Integer> cursor = mapping.get(field.name);
+            if (cursor == null) {
+                final List<Integer> holder = new ArrayList<>(16);
+                holder.add(index);
+                mapping.set(field.name, holder);
+            } else {
+                cursor.add(index);
+            }
         }
         return mapping;
     }

--- a/src/main/java/io/netty/incubator/codec/http3/QpackStaticTable.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackStaticTable.java
@@ -209,8 +209,6 @@ final class QpackStaticTable {
     private static CharSequenceMap<List<Integer>> createMap(int length) {
         CharSequenceMap<List<Integer>> mapping =
             new CharSequenceMap<List<Integer>>(true, UnsupportedValueConverter.<List<Integer>>instance(), length);
-        // Iterate through the static table in reverse order to
-        // save the smallest index for a given name in the map.
         for (int index = 0; index < length; index++) {
             final QpackHeaderField field = getField(index);
             final List<Integer> cursor = mapping.get(field.name);


### PR DESCRIPTION
Motivation:

QPACK static table is somewhat more complicated that the one used in HPACK. It's larger and it contains non-consequent names ranges, e.g. `:status` could be found in the beginning and in the end of the table. Because of this, caching only a single name position in `STATIC_INDEX_BY_NAME` is not enough in most cases.

Modifications:

* `STATIC_INDEX_BY_NAME` is now a mapping from name to list of all positions when name is used in the original table
* Lookup procedure scans lineally only positions where name is used, drastically reducing number of conditional checks
* `QpackUtil.equalsVariableTime` is not executed again for each lookup (as the equality is guaranteed by index)

Result:

Significantly better performance 

```
Benchmark                                                           Mode  Cnt         Score          Error  Units
QpackFastStaticTableBenchmark.findFieldNameAndValueMatchFirst      thrpt    5  25015707.035 ± 13617672.146  ops/s
QpackStaticTableBenchmark.findFieldNameAndValueMatchFirst          thrpt    5  26434708.089 ±   247520.213  ops/s
QpackFastStaticTableBenchmark.findFieldNameAndValueMatchLast       thrpt    5   9069864.655 ±   908320.472  ops/s
QpackStaticTableBenchmark.findFieldNameAndValueMatchLast           thrpt    5   3488414.264 ±   106982.061  ops/s
QpackFastStaticTableBenchmark.findFieldNameRefForEmptyField        thrpt    5  33263344.831 ±  4471887.853  ops/s
QpackStaticTableBenchmark.findFieldNameRefForEmptyField            thrpt    5   4705893.693 ±  1725487.755  ops/s
QpackFastStaticTableBenchmark.findFieldNameRefForMultipleMatches   thrpt    5  20757530.742 ±  4731214.072  ops/s
QpackStaticTableBenchmark.findFieldNameRefForMultipleMatches       thrpt    5   3806580.181 ±   540619.433  ops/s
QpackFastStaticTableBenchmark.findFieldNameRefForSingleMatch       thrpt    5  36276023.843 ±  5773811.720  ops/s
QpackStaticTableBenchmark.findFieldNameRefForSingleMatch           thrpt    5   4862353.040 ±    54342.573  ops/s
QpackFastStaticTableBenchmark.findFieldNotFound                    thrpt    5  72957458.104 ±   911422.965  ops/s
QpackStaticTableBenchmark.findFieldNotFound                        thrpt    5  68383305.955 ±  7466944.769  ops/s
```

P.S. HPACK lookup could be improved using similar approach, it won't even require to change the structure of the index there. Working on a PR for `codec-http2` package.