### PR TITLE
Dont add Http3FrameEncoder / Http3FrameDecoder to the QPACK encoder /…

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameDecoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameDecoder.java
@@ -35,9 +35,6 @@ public final class Http3FrameDecoder extends ByteToMessageDecoder {
     private long type = -1;
     private long payLoadLength = -1;
 
-    // TODO: Do something with this...
-    private boolean fin;
-
     Http3FrameDecoder(QpackDecoder qpackDecoder) {
         this.qpackDecoder = ObjectUtil.checkNotNull(qpackDecoder, "qpackDecoder");
     }
@@ -47,7 +44,6 @@ public final class Http3FrameDecoder extends ByteToMessageDecoder {
         ByteBuf buffer;
         if (msg instanceof QuicStreamFrame) {
             QuicStreamFrame streamFrame = (QuicStreamFrame) msg;
-            fin = streamFrame.hasFin();
             buffer = streamFrame.content().retain();
             streamFrame.release();
         } else {
@@ -143,12 +139,6 @@ public final class Http3FrameDecoder extends ByteToMessageDecoder {
         } finally {
             in.readerIndex(readerIndex + payLoadLength);
         }
-    }
-
-    @Override
-    protected void decodeLast(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
-        super.decodeLast(ctx, in, out);
-        fin = true;
     }
 
     private static Http3SettingsFrame decodeSettings(ByteBuf in, int payLoadLength) {

--- a/src/main/java/io/netty/incubator/codec/http3/Http3UnidirectionalStreamHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3UnidirectionalStreamHandler.java
@@ -61,11 +61,9 @@ abstract class Http3UnidirectionalStreamHandler extends ByteToMessageDecoder {
         } else if (type == 0x02) {
             // See https://quicwg.org/base-drafts/draft-ietf-quic-qpack.html#enc-dec-stream-def
             initQpackEncoderStream(streamChannel);
-            streamChannel.pipeline().addFirst(new Http3FrameEncoder(qpackEncoder), new Http3FrameDecoder(qpackDecoder));
         } else if (type == 0x03) {
             // See https://quicwg.org/base-drafts/draft-ietf-quic-qpack.html#enc-dec-stream-def
             initQpackDecoderStream(streamChannel);
-            streamChannel.pipeline().addFirst(new Http3FrameEncoder(qpackEncoder), new Http3FrameDecoder(qpackDecoder));
         } else {
             if (initUnknownStream((QuicStreamChannel) ctx.channel(), type, in)) {
                 streamChannel.pipeline().addFirst(new Http3FrameEncoder(qpackEncoder),


### PR DESCRIPTION
… decoder stream channel

Motivation:

QPACK streams dont use HTTP3 frames so dont add the encoder / decoder to the pipeline. Beside this we also dont need to special handle the fin flag in QuicStreamFrame

Modifications:

- Remove the adding of the encoder / decoder for QPACK streams
- Remove code related to fin that we not need

Result:

Correct init of QPACK streams