### PR TITLE
Combine Http3FrameDecoder and Http3FrameEncoder into Http3FrameCodec

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameCodec.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameCodec.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.channel.CombinedChannelDuplexHandler;
+import io.netty.util.internal.ObjectUtil;
+
+import java.util.function.Supplier;
+
+/**
+ * Codec that handles decoding and encoding of {@link Http3Frame}s.
+ */
+final class Http3FrameCodec extends CombinedChannelDuplexHandler<Http3FrameDecoder, Http3FrameEncoder> {
+    Http3FrameCodec(QpackDecoder qpackDecoder, QpackEncoder qpackEncoder) {
+        super(new Http3FrameDecoder(qpackDecoder), new Http3FrameEncoder(qpackEncoder));
+    }
+
+    static Supplier<Http3FrameCodec> newSupplier(QpackDecoder qpackDecoder, QpackEncoder qpackEncoder) {
+        ObjectUtil.checkNotNull(qpackDecoder, "qpackDecoder");
+        ObjectUtil.checkNotNull(qpackEncoder, "qpackEncoder");
+
+        // QPACK decoder and encoder are shared between streams in a connection.
+        return () ->  new Http3FrameCodec(qpackDecoder, qpackEncoder);
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameDecoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameDecoder.java
@@ -29,7 +29,7 @@ import static io.netty.incubator.codec.http3.Http3CodecUtils.readVariableLengthI
 /**
  * Decodes {@link Http3Frame}s.
  */
-public final class Http3FrameDecoder extends ByteToMessageDecoder {
+final class Http3FrameDecoder extends ByteToMessageDecoder {
     private final QpackDecoder qpackDecoder;
 
     private long type = -1;

--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameEncoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameEncoder.java
@@ -29,7 +29,7 @@ import java.util.function.BiConsumer;
 import static io.netty.incubator.codec.http3.Http3CodecUtils.numBytesForVariableLengthInteger;
 import static io.netty.incubator.codec.http3.Http3CodecUtils.writeVariableLengthInteger;
 
-public final class Http3FrameEncoder extends ChannelOutboundHandlerAdapter {
+final class Http3FrameEncoder extends ChannelOutboundHandlerAdapter {
     private final QpackEncoder qpackEncoder;
 
     Http3FrameEncoder(QpackEncoder qpackEncoder) {


### PR DESCRIPTION
Motivation:

0a925f2787dec567428ab721c80dd817154de09e did fix a problem related to putting the decoder / encoder into the right position of the pipeline. That said we can make this even easier by just combine the decoder and encoder into one handler and use replace.

Modifications:

Introduce Http3FrameCodec and use it everywhere

Result:

Less error-prone code