### PR TITLE
Remove HTTP3 dependent code from the qpack implementation.

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameCodec.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameCodec.java
@@ -24,15 +24,16 @@ import java.util.function.Supplier;
  * Codec that handles decoding and encoding of {@link Http3Frame}s.
  */
 final class Http3FrameCodec extends CombinedChannelDuplexHandler<Http3FrameDecoder, Http3FrameEncoder> {
-    Http3FrameCodec(QpackDecoder qpackDecoder, QpackEncoder qpackEncoder) {
-        super(new Http3FrameDecoder(qpackDecoder), new Http3FrameEncoder(qpackEncoder));
+    Http3FrameCodec(QpackDecoder qpackDecoder, long maxHeaderListSize, QpackEncoder qpackEncoder) {
+        super(new Http3FrameDecoder(qpackDecoder, maxHeaderListSize), new Http3FrameEncoder(qpackEncoder));
     }
 
-    static Supplier<Http3FrameCodec> newSupplier(QpackDecoder qpackDecoder, QpackEncoder qpackEncoder) {
+    static Supplier<Http3FrameCodec> newSupplier(QpackDecoder qpackDecoder,
+                                                 long maxHeaderListSize, QpackEncoder qpackEncoder) {
         ObjectUtil.checkNotNull(qpackDecoder, "qpackDecoder");
         ObjectUtil.checkNotNull(qpackEncoder, "qpackEncoder");
 
         // QPACK decoder and encoder are shared between streams in a connection.
-        return () ->  new Http3FrameCodec(qpackDecoder, qpackEncoder);
+        return () ->  new Http3FrameCodec(qpackDecoder, maxHeaderListSize, qpackEncoder);
     }
 }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3HeadersSink.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3HeadersSink.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import static io.netty.incubator.codec.http3.Http3Headers.PseudoHeaderName.getPseudoHeader;
+import static io.netty.incubator.codec.http3.Http3Headers.PseudoHeaderName.hasPseudoHeaderFormat;
+
+/**
+ * {@link io.netty.incubator.codec.http3.QpackDecoder.Sink} that does add header names and values to
+ * {@link Http3Headers} while also validate these.
+ */
+final class Http3HeadersSink implements QpackDecoder.Sink {
+    private final Http3Headers headers;
+    private final long maxHeaderListSize;
+    private final boolean validate;
+    private long headersLength;
+    private boolean exceededMaxLength;
+    private Http3Exception validationException;
+    private HeaderType previousType;
+
+    Http3HeadersSink(Http3Headers headers, long maxHeaderListSize, boolean validate) {
+        this.headers = headers;
+        this.maxHeaderListSize = maxHeaderListSize;
+        this.validate = validate;
+    }
+
+    /**
+     * This method must be called after the sink is used.
+     */
+    void finish() throws Http3Exception {
+        if (exceededMaxLength) {
+            throw new Http3Exception(
+                    String.format("Header size exceeded max allowed size (%d)", maxHeaderListSize));
+        } else if (validationException != null) {
+            throw validationException;
+        }
+    }
+
+    @Override
+    public void appendToHeaderList(CharSequence name, CharSequence value) {
+        headersLength += QpackHeaderField.sizeOf(name, value);
+        exceededMaxLength |= headersLength > maxHeaderListSize;
+
+        if (exceededMaxLength || validationException != null) {
+            // We don't store the header since we've already failed validation requirements.
+            return;
+        }
+
+        if (validate) {
+            try {
+                previousType = validate(name, previousType);
+            } catch (Http3Exception ex) {
+                validationException = ex;
+                return;
+            }
+        }
+
+        headers.add(name, value);
+    }
+
+    private static HeaderType validate(CharSequence name, HeaderType previousHeaderType) throws Http3Exception {
+        if (hasPseudoHeaderFormat(name)) {
+            if (previousHeaderType == HeaderType.REGULAR_HEADER) {
+                throw new Http3Exception(String.format("Pseudo-header field '%s' found after regular header.", name));
+            }
+
+            final Http3Headers.PseudoHeaderName pseudoHeader = getPseudoHeader(name);
+            if (pseudoHeader == null) {
+                throw new Http3Exception(String.format("Invalid HTTP/3 pseudo-header '%s' encountered.", name));
+            }
+
+            final HeaderType currentHeaderType = pseudoHeader.isRequestOnly() ?
+                    HeaderType.REQUEST_PSEUDO_HEADER : HeaderType.RESPONSE_PSEUDO_HEADER;
+            if (previousHeaderType != null && currentHeaderType != previousHeaderType) {
+                throw new Http3Exception(String.format("Mix of request and response pseudo-headers."));
+            }
+
+            return currentHeaderType;
+        }
+
+        return HeaderType.REGULAR_HEADER;
+    }
+
+    private enum HeaderType {
+        REGULAR_HEADER,
+        REQUEST_PSEUDO_HEADER,
+        RESPONSE_PSEUDO_HEADER
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
@@ -34,9 +34,10 @@ import java.util.function.Supplier;
  * Handler that handles <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32">HTTP3</a> for the server-side.
  */
 public final class Http3ServerConnectionHandler extends ChannelInboundHandlerAdapter {
+    private static final long DEFAULT_MAX_HEADER_LIST_SIZE = 0xffffffffL;
 
     private final Supplier<Http3FrameCodec> codecSupplier =
-            Http3FrameCodec.newSupplier(new QpackDecoder(), new QpackEncoder());
+            Http3FrameCodec.newSupplier(new QpackDecoder(), DEFAULT_MAX_HEADER_LIST_SIZE, new QpackEncoder());
     private final Http3SettingsFrame localSettings;
     private final ChannelHandler requestStreamHandler;
     private final ChannelHandler controlStreamHandler;

--- a/src/main/java/io/netty/incubator/codec/http3/QpackDecoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackDecoder.java
@@ -18,51 +18,20 @@ package io.netty.incubator.codec.http3;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.AsciiString;
 
-import static io.netty.util.internal.ObjectUtil.checkPositive;
-import static io.netty.incubator.codec.http3.Http3Headers.PseudoHeaderName.getPseudoHeader;
-import static io.netty.incubator.codec.http3.Http3Headers.PseudoHeaderName.hasPseudoHeaderFormat;
-
 final class QpackDecoder {
 
-    private static final Http3Exception HEADER_ILLEGAL_INDEX_VALUE =
-        new Http3Exception("QPACK - illegal index value");
-    private static final Http3Exception NAME_ILLEGAL_INDEX_VALUE =
-        new Http3Exception("QPACK - illegal index value");
-
-    private static final long DEFAULT_MAX_HEADER_LIST_SIZE = 0xffffffffL;
+    private static final QpackException HEADER_ILLEGAL_INDEX_VALUE =
+            QpackException.newStatic(QpackDecoder.class, "getIndexedHeader(...)", "QPACK - illegal index value");
+    private static final QpackException NAME_ILLEGAL_INDEX_VALUE =
+            QpackException.newStatic(QpackDecoder.class, "getIndexedName(...)", "QPACK - illegal index value");
 
     private final QpackHuffmanDecoder huffmanDecoder = new QpackHuffmanDecoder();
 
-    private long maxHeaderListSize;
-
     /**
-     * Create a new instance.
-     */
-    QpackDecoder() {
-        this(DEFAULT_MAX_HEADER_LIST_SIZE);
-    }
-
-    /**
-     * Create a new instance.
-     */
-    QpackDecoder(long maxHeaderListSize) {
-        this.maxHeaderListSize = checkPositive(maxHeaderListSize, "maxHeaderListSize");
-    }
-
-    /**
-     * Decode the header block into header fields.
-     * <p>
+     * Decode the header block and add these to the {@link Sink}.
      * This method assumes the entire header block is contained in {@code in}.
      */
-    public void decodeHeaders(ByteBuf in, Http3Headers headers, boolean validateHeaders) throws Http3Exception {
-        Http3HeadersSink sink = new Http3HeadersSink(headers, maxHeaderListSize, validateHeaders);
-        decode(in, sink);
-
-        // Throws exception if detected any problem so far
-        sink.finish();
-    }
-
-    private void decode(ByteBuf in, Sink sink) throws Http3Exception {
+    public void decode(ByteBuf in, Sink sink) throws QpackException {
         // Required Insert Count
         // https://tools.ietf.org/html/draft-ietf-quic-qpack-19#section-4.5.1.1
         decodePrefixedInteger(in, 8);
@@ -86,7 +55,7 @@ final class QpackDecoder {
         }
     }
 
-    private long decodePrefixedInteger(ByteBuf in, int prefixLength) {
+    private static long decodePrefixedInteger(ByteBuf in, int prefixLength) {
         int nbits = (1 << prefixLength) - 1;
         int first = in.readByte() & nbits;
         if (first < nbits) {
@@ -105,7 +74,7 @@ final class QpackDecoder {
         return i;
     }
 
-    private void decodeIndexed(ByteBuf in, Sink sink) throws Http3Exception {
+    private static void decodeIndexed(ByteBuf in, Sink sink) throws QpackException {
         if ((in.getByte(in.readerIndex()) & 0x40) == 0x40) {
             final int staticIndex = (int) decodePrefixedInteger(in, 6);
             final QpackHeaderField field = getIndexedHeader(staticIndex);
@@ -115,7 +84,7 @@ final class QpackDecoder {
         }
     }
 
-    private void decodeLiteralWithNameReference(ByteBuf in, Sink sink) throws Http3Exception {
+    private void decodeLiteralWithNameReference(ByteBuf in, Sink sink) throws QpackException {
         if ((in.getByte(in.readerIndex()) & 0x10) == 0x10) {
             final int staticNameIndex = (int) decodePrefixedInteger(in, 4);
             final CharSequence name = getIndexedName(staticNameIndex);
@@ -126,23 +95,23 @@ final class QpackDecoder {
         }
     }
 
-    private void decodeLiteral(ByteBuf in, Sink sink) throws Http3Exception {
+    private void decodeLiteral(ByteBuf in, Sink sink) throws QpackException {
         final CharSequence name = decodePrefixedStringLiteral(in, (byte) 0x8, 3);
         final CharSequence value = decodePrefixedStringLiteral(in);
         sink.appendToHeaderList(name, value);
     }
 
-    private CharSequence decodePrefixedStringLiteral(ByteBuf in) throws Http3Exception {
+    private CharSequence decodePrefixedStringLiteral(ByteBuf in) throws QpackException {
         return decodePrefixedStringLiteral(in, (byte) 0x80, 7);
     }
 
-    private CharSequence decodePrefixedStringLiteral(ByteBuf in, byte mask, int prefix) throws Http3Exception {
+    private CharSequence decodePrefixedStringLiteral(ByteBuf in, byte mask, int prefix) throws QpackException {
         final boolean huffmanEncoded = (in.getByte(in.readerIndex()) & mask) == mask;
         final int length = (int) decodePrefixedInteger(in, prefix);
         return decodeStringLiteral(in, length, huffmanEncoded);
     }
 
-    private CharSequence decodeStringLiteral(ByteBuf in, int length, boolean huffmanEncoded) throws Http3Exception {
+    private CharSequence decodeStringLiteral(ByteBuf in, int length, boolean huffmanEncoded) throws QpackException {
         if (huffmanEncoded) {
             return huffmanDecoder.decode(in, length);
         }
@@ -151,7 +120,7 @@ final class QpackDecoder {
         return new AsciiString(buf, false);
     }
 
-    private CharSequence getIndexedName(int index) throws Http3Exception {
+    private static CharSequence getIndexedName(int index) throws QpackException {
         if (index <= QpackStaticTable.length) {
             final QpackHeaderField field = QpackStaticTable.getField(index);
             return field.name;
@@ -159,92 +128,14 @@ final class QpackDecoder {
         throw NAME_ILLEGAL_INDEX_VALUE;
     }
 
-    private QpackHeaderField getIndexedHeader(int index) throws Http3Exception {
+    private static QpackHeaderField getIndexedHeader(int index) throws QpackException {
         if (index <= QpackStaticTable.length) {
             return QpackStaticTable.getField(index);
         }
         throw HEADER_ILLEGAL_INDEX_VALUE;
     }
 
-    private static HeaderType validate(CharSequence name, HeaderType previousHeaderType) throws Http3Exception {
-        if (hasPseudoHeaderFormat(name)) {
-            if (previousHeaderType == HeaderType.REGULAR_HEADER) {
-                throw new Http3Exception(String.format("Pseudo-header field '%s' found after regular header.", name));
-            }
-
-            final Http3Headers.PseudoHeaderName pseudoHeader = getPseudoHeader(name);
-            if (pseudoHeader == null) {
-                throw new Http3Exception(String.format("Invalid HTTP/3 pseudo-header '%s' encountered.", name));
-            }
-
-            final HeaderType currentHeaderType = pseudoHeader.isRequestOnly() ?
-                    HeaderType.REQUEST_PSEUDO_HEADER : HeaderType.RESPONSE_PSEUDO_HEADER;
-            if (previousHeaderType != null && currentHeaderType != previousHeaderType) {
-                throw new Http3Exception(String.format("Mix of request and response pseudo-headers."));
-            }
-
-            return currentHeaderType;
-        }
-
-        return HeaderType.REGULAR_HEADER;
-    }
-
-    private enum HeaderType {
-        REGULAR_HEADER,
-        REQUEST_PSEUDO_HEADER,
-        RESPONSE_PSEUDO_HEADER
-    }
-
-    private interface Sink {
+    interface Sink {
         void appendToHeaderList(CharSequence name, CharSequence value);
-        void finish() throws Http3Exception;
-    }
-
-    private static final class Http3HeadersSink implements Sink {
-        private final Http3Headers headers;
-        private final long maxHeaderListSize;
-        private final boolean validate;
-        private long headersLength;
-        private boolean exceededMaxLength;
-        private Http3Exception validationException;
-        private HeaderType previousType;
-
-        Http3HeadersSink(Http3Headers headers, long maxHeaderListSize, boolean validate) {
-            this.headers = headers;
-            this.maxHeaderListSize = maxHeaderListSize;
-            this.validate = validate;
-        }
-
-        @Override
-        public void finish() throws Http3Exception {
-            if (exceededMaxLength) {
-                throw new Http3Exception(
-                    String.format("Header size exceeded max allowed size (%d)", maxHeaderListSize));
-            } else if (validationException != null) {
-                throw validationException;
-            }
-        }
-
-        @Override
-        public void appendToHeaderList(CharSequence name, CharSequence value) {
-            headersLength += QpackHeaderField.sizeOf(name, value);
-            exceededMaxLength |= headersLength > maxHeaderListSize;
-
-            if (exceededMaxLength || validationException != null) {
-                // We don't store the header since we've already failed validation requirements.
-                return;
-            }
-
-            if (validate) {
-                try {
-                    previousType = QpackDecoder.validate(name, previousType);
-                } catch (Http3Exception ex) {
-                    validationException = ex;
-                    return;
-                }
-            }
-
-            headers.add(name, value);
-        }
     }
 }

--- a/src/main/java/io/netty/incubator/codec/http3/QpackException.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.util.internal.ThrowableUtil;
+
+/**
+ * Exception thrown if an error happens during QPACK processing.
+ */
+public final class QpackException extends Exception {
+
+    private QpackException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    static QpackException newStatic(Class<?> clazz, String method, String message) {
+        return ThrowableUtil.unknownStackTrace(new QpackException(message, null, false, false), clazz, method);
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/http3/QpackHuffmanDecoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackHuffmanDecoder.java
@@ -4646,7 +4646,8 @@ final class QpackHuffmanDecoder implements ByteProcessor {
             HUFFMAN_FAIL << 8,
     };
 
-    private static final Http3Exception BAD_ENCODING = new Http3Exception("QPACK - Bad Encoding");
+    private static final QpackException BAD_ENCODING =  QpackException.newStatic(QpackHuffmanDecoder.class,
+            "decode(...)", "QPACK - Bad Encoding");
 
     private byte[] dest;
     private int k;
@@ -4659,9 +4660,9 @@ final class QpackHuffmanDecoder implements ByteProcessor {
      *
      * @param buf the string literal to be decoded
      * @return the output stream for the compressed data
-     * @throws Http3Exception EOS Decoded
+     * @throws QpackException EOS Decoded
      */
-    public AsciiString decode(ByteBuf buf, int length) throws Http3Exception {
+    public AsciiString decode(ByteBuf buf, int length) throws QpackException {
         if (length == 0) {
             return AsciiString.EMPTY_STRING;
         }

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameEncoderDecoderTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameEncoderDecoderTest.java
@@ -138,7 +138,7 @@ public class Http3FrameEncoderDecoderTest {
 
     private void testFrameEncodedAndDecoded(Http3Frame frame) {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(new Http3FrameEncoder(new QpackEncoder()));
-        EmbeddedChannel decoderChannel = new EmbeddedChannel(new Http3FrameDecoder(new QpackDecoder()));
+        EmbeddedChannel decoderChannel = new EmbeddedChannel(new Http3FrameDecoder(new QpackDecoder(), 1024));
 
         assertTrue(encoderChannel.writeOutbound(retainAndDuplicate(frame)));
         ByteBuf buffer = encoderChannel.readOutbound();

--- a/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDecoderTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDecoderTest.java
@@ -25,7 +25,7 @@ import io.netty.util.AsciiString;
 
 public class QpackEncoderDecoderTest {
     @Test
-    public void testEncodeDecode() throws Http3Exception {
+    public void testEncodeDecode() throws QpackException {
         final QpackEncoder encoder = new QpackEncoder();
         final QpackDecoder decoder = new QpackDecoder();
 
@@ -41,7 +41,7 @@ public class QpackEncoderDecoderTest {
         final Http3Headers decHeaders = new DefaultHttp3Headers();
 
         encoder.encodeHeaders(out, encHeaders);
-        decoder.decodeHeaders(out, decHeaders, false);
+        decoder.decode(out, new Http3HeadersSink(decHeaders, 1024, false));
 
         assertEquals(5, decHeaders.size());
         assertEquals(new AsciiString("netty.quic"), decHeaders.authority());


### PR DESCRIPTION
Motivation:

The QPACK decoder / encoder should not depend on HTTP3 and also throw their own exception type to make it easier to convert stuff to the right HTTP3 error code.

Modifications:

- Introduce QpackException and use it in the QPACK code
- Move Http3HeadersSink out of QpackDecoder and let it throw Http3Exception during header validation
- Adjust tests

Result:

QPACK not depends on http3 stuff anymore