### PR TITLE
Add Http3ErrorCode enum and start to add validation for HTTP3 spec

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
@@ -16,6 +16,11 @@
 package io.netty.incubator.codec.http3;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.incubator.codec.quic.QuicStreamChannel;
+import io.netty.util.CharsetUtil;
 
 final class Http3CodecUtils {
 
@@ -126,5 +131,17 @@ final class Http3CodecUtils {
             return 4;
         }
         return 1;
+    }
+
+    static void closeParent(Channel channel, Http3ErrorCode errorCode, String msg) {
+        QuicChannel parent = (QuicChannel) channel.parent();
+        final ByteBuf buffer;
+        if (msg != null) {
+            buffer = parent.alloc().directBuffer();
+            buffer.writeCharSequence(msg, CharsetUtil.US_ASCII);
+        } else {
+            buffer = Unpooled.EMPTY_BUFFER;
+        }
+        parent.close(true, errorCode.code, buffer);
     }
 }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ErrorCode.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ErrorCode.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+/**
+ * Different <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-8.1">HTTP3 error codes</a>.
+ */
+public enum Http3ErrorCode {
+
+    /**
+     *  No error. This is used when the connection or stream needs to be closed, but there is no error to signal.
+     */
+    H3_NO_ERROR(0x100),
+
+    /**
+     * Peer violated protocol requirements in a way that does not match a more specific error code,
+     * or endpoint declines to use the more specific error code.
+     */
+    H3_GENERAL_PROTOCOL_ERROR(0x101),
+
+    /**
+     * An internal error has occurred in the HTTP stack.
+     */
+    H3_INTERNAL_ERROR(0x102),
+
+    /**
+     * The endpoint detected that its peer created a stream that it will not accept.
+     */
+    H3_STREAM_CREATION_ERROR(0x103),
+
+    /**
+     * A stream required by the HTTP/3 connection was closed or reset.
+     */
+    H3_CLOSED_CRITICAL_STREAM(0x104),
+
+    /**
+     * A frame was received that was not permitted in the current state or on the current stream.
+     */
+    H3_FRAME_UNEXPECTED(0x105),
+
+    /**
+     * A frame that fails to satisfy layout requirements or with an invalid size was received.
+     */
+    H3_FRAME_ERROR(0x106),
+
+    /**
+     * The endpoint detected that its peer is exhibiting a behavior that might be generating excessive load.
+     */
+    H3_EXCESSIVE_LOAD(0x107),
+
+    /**
+     * A Stream ID or Push ID was used incorrectly, such as exceeding a limit, reducing a limit, or being reused.
+     */
+    H3_ID_ERROR(0x108),
+
+    /**
+     * An endpoint detected an error in the payload of a SETTINGS frame.
+     */
+    H3_SETTINGS_ERROR(0x109),
+
+    /**
+     * No SETTINGS frame was received at the beginning of the control stream.
+     */
+    H3_MISSING_SETTINGS(0x10a),
+
+    /**
+     * A server rejected a request without performing any application processing.
+     */
+    H3_REQUEST_REJECTED(0x10b),
+
+    /**
+     * The request or its response (including pushed response) is cancelled.
+     */
+    H3_REQUEST_CANCELLED(0x10c),
+
+    /**
+     * The client's stream terminated without containing a fully-formed request.
+     */
+    H3_REQUEST_INCOMPLETE(0x10d),
+
+    /**
+     * The TCP connection established in response to a CONNECT request was reset or abnormally closed.
+     */
+    H3_CONNECT_ERROR(0x10f),
+
+    /**
+     * The requested operation cannot be served over HTTP/3. The peer should retry over HTTP/1.1.
+     */
+    H3_VERSION_FALLBACK(0x110),
+
+    /**
+     * The decoder failed to interpret an encoded field section and is not able to continue decoding that field section.
+     */
+    QPACK_DECOMPRESSION_FAILED(0x200),
+
+    /**
+     * The decoder failed to interpret an encoder instruction received on the encoder stream.
+     */
+    QPACK_ENCODER_STREAM_ERROR(0x201),
+
+    /**
+     * The encoder failed to interpret a decoder instruction received on the decoder stream.
+     */
+    QPACK_DECODER_STREAM_ERROR(0x202);
+
+    final int code;
+
+    Http3ErrorCode(int code) {
+        this.code = code;
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameDecoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameDecoder.java
@@ -56,7 +56,7 @@ final class Http3FrameDecoder extends ByteToMessageDecoder {
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
         if (!in.isReadable()) {
             return;
         }
@@ -98,19 +98,8 @@ final class Http3FrameDecoder extends ByteToMessageDecoder {
                         // HEADERS
                         // https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.2
                         Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
-                        try {
-                            decodeHeaders(headersFrame.headers(), in);
+                        if (decodeHeaders(ctx, headersFrame.headers(), in)) {
                             out.add(headersFrame);
-                        } catch (QpackException e) {
-                            // Must be treated as a connection error.
-                            Http3CodecUtils.closeParent(
-                                    ctx.channel(), Http3ErrorCode.QPACK_DECOMPRESSION_FAILED,
-                                    "Decompression of header block failed.");
-                        } catch (Http3HeadersValidationException e) {
-                            ctx.fireExceptionCaught(e);
-                            // We should close the stream.
-                            // See https://tools.ietf.org/html/draft-ietf-quic-http-32#section-4.1.3
-                            ctx.close();
                         }
                         break;
                     case 0x3:
@@ -130,19 +119,8 @@ final class Http3FrameDecoder extends ByteToMessageDecoder {
                         int pushPromiseIdLen = numBytesForVariableLengthInteger(in.getByte(in.readerIndex()));
                         Http3PushPromiseFrame pushPromiseFrame = new DefaultHttp3PushPromiseFrame(
                                 readVariableLengthInteger(in, pushPromiseIdLen));
-                        try {
-                            decodeHeaders(pushPromiseFrame.headers(), in);
+                        if (decodeHeaders(ctx, pushPromiseFrame.headers(), in)) {
                             out.add(pushPromiseFrame);
-                        } catch (QpackException e) {
-                            // Must be treated as a connection error.
-                            Http3CodecUtils.closeParent(
-                                    ctx.channel(), Http3ErrorCode.QPACK_DECOMPRESSION_FAILED,
-                                    "Decompression of header block failed.");
-                        } catch (Http3HeadersValidationException e) {
-                            ctx.fireExceptionCaught(e);
-                            // We should close the stream.
-                            // See https://tools.ietf.org/html/draft-ietf-quic-http-32#section-4.1.3
-                            ctx.close();
                         }
                         break;
                     case 0x7:
@@ -188,12 +166,25 @@ final class Http3FrameDecoder extends ByteToMessageDecoder {
      * <p>
      * This method assumes the entire header block is contained in {@code in}.
      */
-    private void decodeHeaders(Http3Headers headers, ByteBuf in)
-            throws Http3HeadersValidationException, QpackException {
-        Http3HeadersSink sink = new Http3HeadersSink(headers, maxHeaderListSize, true);
-        qpackDecoder.decode(in, sink);
-
-        // Throws exception if detected any problem so far
-        sink.finish();
+    private boolean decodeHeaders(ChannelHandlerContext ctx, Http3Headers headers, ByteBuf in) {
+        try {
+            Http3HeadersSink sink = new Http3HeadersSink(headers, maxHeaderListSize, true);
+            qpackDecoder.decode(in, sink);
+            // Throws exception if detected any problem so far
+            sink.finish();
+        } catch (QpackException e) {
+            // Must be treated as a connection error.
+            Http3CodecUtils.closeParent(
+                    ctx.channel(), Http3ErrorCode.QPACK_DECOMPRESSION_FAILED,
+                    "Decompression of header block failed.");
+            return false;
+        } catch (Http3HeadersValidationException e) {
+            ctx.fireExceptionCaught(e);
+            // We should close the stream.
+            // See https://tools.ietf.org/html/draft-ietf-quic-http-32#section-4.1.3
+            ctx.close();
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandler.java
@@ -55,12 +55,15 @@ class Http3FrameTypeValidationHandler<T extends Http3Frame> extends ChannelDuple
             channelRead(ctx, cast(msg));
         } else {
             ReferenceCountUtil.release(msg);
-            // TODO: Handle me with the right error.
-            throw new UnsupportedMessageTypeException();
+            frameTypeUnexpected(ctx);
         }
     }
 
     public void channelRead(ChannelHandlerContext ctx, T frame) throws Exception {
         ctx.fireChannelRead(frame);
+    }
+
+    private static void frameTypeUnexpected(ChannelHandlerContext ctx) {
+        Http3CodecUtils.closeParent(ctx.channel(), Http3ErrorCode.H3_FRAME_UNEXPECTED, "Frame type unexpected");
     }
 }


### PR DESCRIPTION
Motivation:

We need to correctly detect errors related to the HTTP3 spec

Modifications:

Add Http3ErrorCode and start to add validations

Result:

Added some validations