### PR TITLE
Add validation for the frame sequence for http3 request streams

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,5 +330,11 @@
       <version>1.1.7</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.6.28</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/io/netty/incubator/codec/http3/Http3Exception.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3Exception.java
@@ -15,10 +15,28 @@
  */
 package io.netty.incubator.codec.http3;
 
-public class Http3Exception extends Exception {
+import io.netty.util.internal.ObjectUtil;
 
-    Http3Exception(String message) {
+/**
+ * An exception related to violate the HTTP3 spec.
+ */
+public final class Http3Exception extends Exception {
+    private final Http3ErrorCode errorCode;
+
+    public Http3Exception(Http3ErrorCode errorCode, String message) {
         super(message);
+        this.errorCode = ObjectUtil.checkNotNull(errorCode, "errorCode");
     }
 
+    public Http3Exception(Http3ErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = ObjectUtil.checkNotNull(errorCode, "errorCode");
+    }
+
+    /**
+     * Returns the related {@link Http3ErrorCode}.
+     */
+    public Http3ErrorCode errorCode() {
+        return errorCode;
+    }
 }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3RequestStreamValidationHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3RequestStreamValidationHandler.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+
+final class Http3RequestStreamValidationHandler extends Http3FrameTypeValidationHandler<Http3RequestStreamFrame> {
+    private enum State {
+        Initial,
+        Started,
+        End
+    }
+    private State readState = State.Initial;
+    private State writeState = State.Initial;
+
+    Http3RequestStreamValidationHandler() {
+        super(Http3RequestStreamFrame.class);
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Http3RequestStreamFrame frame, ChannelPromise promise) {
+        switch (writeState) {
+            case Initial:
+                if (!(frame instanceof Http3HeadersFrame)) {
+                    frameTypeUnexpected(promise, frame);
+                    return;
+                }
+                writeState = State.Started;
+                break;
+            case Started:
+                if (frame instanceof Http3HeadersFrame) {
+                    // trailers
+                    writeState = State.End;
+                }
+                break;
+            case End:
+                frameTypeUnexpected(promise, frame);
+                return;
+            default:
+                throw new Error();
+        }
+        ctx.write(frame, promise);
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Http3RequestStreamFrame frame) {
+        switch (readState) {
+            case Initial:
+                if (!(frame instanceof Http3HeadersFrame)) {
+                    frameTypeUnexpected(ctx, frame);
+                    return;
+                }
+                readState = State.Started;
+                break;
+            case Started:
+                if (frame instanceof Http3HeadersFrame) {
+                    // trailers
+                    readState = State.End;
+                }
+                break;
+            case End:
+                frameTypeUnexpected(ctx, frame);
+                return;
+            default:
+                throw new Error();
+        }
+        ctx.fireChannelRead(frame);
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
@@ -97,7 +97,7 @@ public final class Http3ServerConnectionHandler extends ChannelInboundHandlerAda
             case BIDIRECTIONAL:
                 // Add the encoder and decoder in the pipeline so we can handle Http3Frames
                 pipeline.addLast(codecSupplier.get());
-                pipeline.addLast(new Http3FrameTypeValidationHandler<>(Http3RequestStreamFrame.class));
+                pipeline.addLast(new Http3RequestStreamValidationHandler());
                 pipeline.addLast(requestStreamHandler);
                 break;
             case UNIDIRECTIONAL:
@@ -158,7 +158,7 @@ public final class Http3ServerConnectionHandler extends ChannelInboundHandlerAda
         }
 
         @Override
-        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        public void channelInactive(ChannelHandlerContext ctx) {
             criticalStreamClosed(ctx);
             ctx.fireChannelInactive();
         }

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandlerTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.DefaultChannelId;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.incubator.codec.quic.QuicChannel;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class Http3FrameTypeValidationHandlerTest {
+
+    protected Http3FrameTypeValidationHandler<Http3RequestStreamFrame> newValidationHandler() {
+        return new Http3FrameTypeValidationHandler<>(Http3RequestStreamFrame.class);
+    }
+
+    @Test
+    public void testValidTypeInbound() {
+        EmbeddedChannel channel = new EmbeddedChannel(newValidationHandler());
+
+        Http3RequestStreamFrame requestStreamFrame = new DefaultHttp3HeadersFrame();
+        assertTrue(channel.writeInbound(requestStreamFrame));
+        Http3RequestStreamFrame read = channel.readInbound();
+        assertEquals(requestStreamFrame, read);
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testValidTypeOutput() {
+        EmbeddedChannel channel = new EmbeddedChannel(newValidationHandler());
+
+        Http3RequestStreamFrame requestStreamFrame = new DefaultHttp3HeadersFrame();
+        assertTrue(channel.writeOutbound(requestStreamFrame));
+        Http3RequestStreamFrame read = channel.readOutbound();
+        assertEquals(requestStreamFrame, read);
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testInvalidTypeInbound() {
+        QuicChannel parent = mock(QuicChannel.class);
+        ArgumentCaptor<ByteBuf> argumentCaptor = ArgumentCaptor.forClass(ByteBuf.class);
+        when(parent.close(anyBoolean(), anyInt(),
+                any(ByteBuf.class))).thenReturn(new DefaultChannelPromise(parent));
+        when(parent.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
+
+        EmbeddedChannel channel = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), true, false,
+                newValidationHandler());
+        Http3ControlStreamFrame requestStreamFrame = new Http3ControlStreamFrame() { };
+        assertFalse(channel.writeInbound(requestStreamFrame));
+        assertFalse(channel.finish());
+        verify(parent).close(eq(true), eq(Http3ErrorCode.H3_FRAME_UNEXPECTED.code), argumentCaptor.capture());
+        argumentCaptor.getValue().release();
+    }
+
+    @Test
+    public void testInvalidTypeOutput() {
+        EmbeddedChannel channel = new EmbeddedChannel(newValidationHandler());
+
+        Http3ControlStreamFrame requestStreamFrame = new Http3ControlStreamFrame() { };
+        try {
+            channel.writeOutbound(requestStreamFrame);
+        } catch (Exception e) {
+            assertException(e);
+        }
+        assertFalse(channel.finish());
+    }
+
+    protected static void assertException(Exception e) {
+        MatcherAssert.assertThat(e, CoreMatchers.instanceOf(Http3Exception.class));
+        Http3Exception exception = (Http3Exception) e;
+        assertEquals(Http3ErrorCode.H3_FRAME_UNEXPECTED, exception.errorCode());
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamValidationHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamValidationHandlerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.DefaultChannelId;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.util.ReferenceCountUtil;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValidationHandlerTest {
+    @Override
+    protected Http3FrameTypeValidationHandler<Http3RequestStreamFrame> newValidationHandler() {
+        return new Http3RequestStreamValidationHandler();
+    }
+
+    @Test
+    public void testInvalidFrameSequenceStartInbound() {
+        QuicChannel parent = mock(QuicChannel.class);
+        ArgumentCaptor<ByteBuf> argumentCaptor = ArgumentCaptor.forClass(ByteBuf.class);
+        when(parent.close(anyBoolean(), anyInt(),
+                any(ByteBuf.class))).thenReturn(new DefaultChannelPromise(parent));
+        when(parent.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
+
+        EmbeddedChannel channel = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), true, false,
+                newValidationHandler());
+        Http3DataFrame dataFrame = new DefaultHttp3DataFrame(Unpooled.buffer());
+        assertFalse(channel.writeInbound(dataFrame));
+        assertFalse(channel.finish());
+        verify(parent).close(eq(true), eq(Http3ErrorCode.H3_FRAME_UNEXPECTED.code), argumentCaptor.capture());
+        argumentCaptor.getValue().release();
+        assertEquals(0, dataFrame.refCnt());
+    }
+
+    @Test
+    public void testInvalidFrameSequenceEndInbound() {
+        QuicChannel parent = mock(QuicChannel.class);
+        ArgumentCaptor<ByteBuf> argumentCaptor = ArgumentCaptor.forClass(ByteBuf.class);
+        when(parent.close(anyBoolean(), anyInt(),
+                any(ByteBuf.class))).thenReturn(new DefaultChannelPromise(parent));
+        when(parent.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
+
+        EmbeddedChannel channel = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), true, false,
+                newValidationHandler());
+        Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
+        Http3DataFrame dataFrame = new DefaultHttp3DataFrame(Unpooled.buffer());
+        Http3DataFrame dataFrame2 = new DefaultHttp3DataFrame(Unpooled.buffer());
+        Http3DataFrame dat3Frame3 = new DefaultHttp3DataFrame(Unpooled.buffer());
+        Http3HeadersFrame trailersFrame = new DefaultHttp3HeadersFrame();
+
+        assertTrue(channel.writeInbound(headersFrame));
+        assertTrue(channel.writeInbound(dataFrame.retainedDuplicate()));
+        assertTrue(channel.writeInbound(dataFrame2.retainedDuplicate()));
+        assertTrue(channel.writeInbound(trailersFrame));
+        assertTrue(channel.writeInbound(dat3Frame3));
+
+        assertTrue(channel.finish());
+        verify(parent).close(eq(true), eq(Http3ErrorCode.H3_FRAME_UNEXPECTED.code), argumentCaptor.capture());
+        argumentCaptor.getValue().release();
+        assertEquals(0, dat3Frame3.refCnt());
+
+        assertFrame(headersFrame, channel.readInbound());
+        assertFrame(dataFrame, channel.readInbound());
+        assertFrame(dataFrame2, channel.readInbound());
+        assertFrame(trailersFrame, channel.readInbound());
+        assertNull(channel.readInbound());
+    }
+
+    @Test
+    public void testInvalidFrameSequenceStartOutbound() {
+        EmbeddedChannel channel = new EmbeddedChannel(newValidationHandler());
+
+        Http3DataFrame dataFrame = new DefaultHttp3DataFrame(Unpooled.buffer());
+        try {
+            channel.writeOutbound(dataFrame);
+        } catch (Exception e) {
+            assertException(e);
+        }
+        assertFalse(channel.finish());
+        assertEquals(0, dataFrame.refCnt());
+    }
+
+    @Test
+    public void testInvalidFrameSequenceEndOutbound() {
+        EmbeddedChannel channel = new EmbeddedChannel(newValidationHandler());
+
+        Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
+        Http3DataFrame dataFrame = new DefaultHttp3DataFrame(Unpooled.buffer());
+        Http3DataFrame dataFrame2 = new DefaultHttp3DataFrame(Unpooled.buffer());
+        Http3DataFrame dat3Frame3 = new DefaultHttp3DataFrame(Unpooled.buffer());
+        Http3HeadersFrame trailersFrame = new DefaultHttp3HeadersFrame();
+        assertTrue(channel.writeOutbound(headersFrame));
+        assertTrue(channel.writeOutbound(dataFrame.retainedDuplicate()));
+        assertTrue(channel.writeOutbound(dataFrame2.retainedDuplicate()));
+        assertTrue(channel.writeOutbound(trailersFrame));
+
+        try {
+            channel.writeOutbound(dat3Frame3);
+        } catch (Exception e) {
+            assertException(e);
+        }
+        assertTrue(channel.finish());
+        assertEquals(0, dat3Frame3.refCnt());
+
+        assertFrame(headersFrame, channel.readOutbound());
+        assertFrame(dataFrame, channel.readOutbound());
+        assertFrame(dataFrame2, channel.readOutbound());
+        assertFrame(trailersFrame, channel.readOutbound());
+        assertNull(channel.readOutbound());
+    }
+
+    private static void assertFrame(Http3Frame expected, Http3Frame actual) {
+        try {
+            assertEquals(expected, actual);
+        } finally {
+            ReferenceCountUtil.release(expected);
+            ReferenceCountUtil.release(actual);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

We should validate that we receive and send frames on the http3 request stream in the correct order and if not signal this back to the remote peer / user.

Modifications:

- Adjust Http3Exception to also wrap the Http3ErrorCode
- Add Http3RequestStreamValidationHandler (and unit test) that validates the correct sequence of frames
- Add unit test for Http3FrameTypeValidationHandler

Result:

Validation for http3 request streams