### PR TITLE
Add validation for frames on the control stream

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
@@ -18,8 +18,8 @@ package io.netty.incubator.codec.http3;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.incubator.codec.quic.QuicChannel;
-import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.util.CharsetUtil;
 
 final class Http3CodecUtils {
@@ -143,5 +143,11 @@ final class Http3CodecUtils {
             buffer = Unpooled.EMPTY_BUFFER;
         }
         parent.close(true, errorCode.code, buffer);
+    }
+
+    static void readIfNoAutoRead(ChannelHandlerContext ctx) {
+        if (!ctx.channel().config().isAutoRead()) {
+            ctx.read();
+        }
     }
 }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamInboundHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamInboundHandler.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.ReferenceCountUtil;
+
+final class Http3ControlStreamInboundHandler extends Http3FrameTypeValidationHandler<Http3ControlStreamFrame> {
+    private final boolean server;
+    private final boolean forwardControlFrames;
+    private boolean firstFrameRead;
+    private Long receivedGoawayId;
+    private Long receivedMaxPushId;
+
+    Http3ControlStreamInboundHandler(boolean server, boolean forwardControlFrames) {
+        super(Http3ControlStreamFrame.class);
+        this.server = server;
+        this.forwardControlFrames = forwardControlFrames;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Http3ControlStreamFrame frame) {
+        final boolean firstFrame;
+        if (!firstFrameRead) {
+            firstFrameRead = true;
+            firstFrame = true;
+        } else {
+            firstFrame = false;
+        }
+        if (firstFrame && !(frame instanceof Http3SettingsFrame)) {
+            Http3CodecUtils.closeParent(ctx.channel(), Http3ErrorCode.H3_MISSING_SETTINGS,
+                    "Missing settings frame.");
+        } else if (frame instanceof Http3SettingsFrame) {
+            // TODO: handle this.
+            Http3SettingsFrame settingsFrame = (Http3SettingsFrame) frame;
+            // As we not support dynamic table yet we dont create QPACK encoder / decoder streams.
+            // Once we support dynamic table this should be done here as well.
+            // TODO: Add QPACK stream creation.
+        } else if (frame instanceof Http3GoAwayFrame) {
+            Http3GoAwayFrame goAwayFrame = (Http3GoAwayFrame) frame;
+            long id = goAwayFrame.id();
+            if (!server && id % 4 != 0) {
+                Http3CodecUtils.closeParent(ctx.channel(), Http3ErrorCode.H3_FRAME_UNEXPECTED,
+                        "GOAWAY received with ID of non-request stream.");
+            } else if (receivedGoawayId != null && id > receivedGoawayId) {
+                Http3CodecUtils.closeParent(ctx.channel(), Http3ErrorCode.H3_ID_ERROR,
+                        "GOAWAY received with ID larger than previously received.");
+            } else {
+                receivedGoawayId = id;
+            }
+        } else if (frame instanceof Http3MaxPushIdFrame) {
+            long id = ((Http3MaxPushIdFrame) frame).id();
+
+            if (!server) {
+                Http3CodecUtils.closeParent(ctx.channel(), Http3ErrorCode.H3_FRAME_UNEXPECTED,
+                        "MAX_PUSH_ID received by client.");
+            } else if (receivedMaxPushId != 0 && id < receivedMaxPushId) {
+                Http3CodecUtils.closeParent(ctx.channel(), Http3ErrorCode.H3_ID_ERROR,
+                        "MAX_PUSH_ID reduced limit.");
+            } else {
+                receivedMaxPushId = id;
+            }
+        } else if (frame instanceof Http3CancelPushFrame) {
+            // TODO: implement me
+        } else {
+            // TODO: Do we need to do something to handle unknown frames
+        }
+
+        if (forwardControlFrames) {
+            // The user did specify ChannelHandler that should be notified about control stream frames.
+            // Let's forward the frame so the user can do something with it.
+            ctx.fireChannelRead(frame);
+        } else {
+            // We handled the frame, release it.
+            ReferenceCountUtil.release(frame);
+        }
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        ctx.fireChannelReadComplete();
+
+        // control streams should always be processed, no matter what the user is doing in terms of
+        // configuration and AUTO_READ.
+        Http3CodecUtils.readIfNoAutoRead(ctx);
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamOutboundHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamOutboundHandler.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.ChannelInputShutdownEvent;
+
+import java.util.function.Supplier;
+
+final class Http3ControlStreamOutboundHandler
+        extends Http3FrameTypeValidationHandler<Http3ControlStreamFrame> {
+    private final Http3SettingsFrame localSettings;
+    private final Supplier<Http3FrameCodec> codecSupplier;
+
+    Http3ControlStreamOutboundHandler(Http3SettingsFrame localSettings,
+                                      Supplier<Http3FrameCodec> codecSupplier) {
+        super(Http3ControlStreamFrame.class);
+        this.localSettings = localSettings;
+        this.codecSupplier = codecSupplier;
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) {
+        // We need to write 0x00 into the stream before doing anything else.
+        // See https://tools.ietf.org/html/draft-ietf-quic-http-32#section-6.2.1
+        // Just allocate 8 bytes which would be the max needed.
+        ByteBuf buffer = ctx.alloc().directBuffer(8);
+        Http3CodecUtils.writeVariableLengthInteger(buffer, 0x00);
+        ctx.write(buffer);
+        // Add the encoder and decoder in the pipeline so we can handle Http3Frames
+        ctx.pipeline().addFirst(codecSupplier.get());
+        final Http3SettingsFrame settingsFrame;
+        if (localSettings == null) {
+            settingsFrame = new DefaultHttp3SettingsFrame();
+        } else {
+            settingsFrame = DefaultHttp3SettingsFrame.copyOf(localSettings);
+        }
+        // As we not support the dynamic table at the moment lets override whatever the user specified and set
+        // the capacity to 0.
+        settingsFrame.put(Http3Constants.SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0L);
+        // If writing of the local settings fails let's just teardown the connection.
+        ctx.writeAndFlush(settingsFrame).addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
+
+        ctx.fireChannelActive();
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        if (evt instanceof ChannelInputShutdownEvent) {
+            criticalStreamClosed(ctx);
+        }
+        ctx.fireUserEventTriggered(evt);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        criticalStreamClosed(ctx);
+        ctx.fireChannelInactive();
+    }
+
+    // See https://tools.ietf.org/html/draft-ietf-quic-http-32#section-6.2.1
+    private void criticalStreamClosed(ChannelHandlerContext ctx) {
+        Http3CodecUtils.closeParent(
+                ctx.channel(), Http3ErrorCode.H3_CLOSED_CRITICAL_STREAM, "Critical stream closed.");
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
@@ -15,17 +15,13 @@
  */
 package io.netty.incubator.codec.http3;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.incubator.codec.quic.QuicChannel;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.incubator.codec.quic.QuicStreamType;
-import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.ObjectUtil;
 
 import java.util.function.Supplier;
@@ -78,11 +74,14 @@ public final class Http3ServerConnectionHandler extends ChannelInboundHandlerAda
         // Once the channel became active we need to create an unidirectional stream and write the Http3SettingsFrame
         // to it. This needs to be the first frame on this stream.
         // https://tools.ietf.org/html/draft-ietf-quic-http-32#section-6.2.1.
-        channel.createStream(QuicStreamType.UNIDIRECTIONAL, new Http3ServerOutboundControlStreamHandler())
+        channel.createStream(QuicStreamType.UNIDIRECTIONAL,
+                new Http3ControlStreamOutboundHandler(localSettings, codecSupplier))
                 .addListener(f -> {
             if (!f.isSuccess()) {
                 // TODO: Handle me the right way.
                 ctx.close();
+            } else {
+                localControlStream = (QuicStreamChannel) f.get();
             }
         });
 
@@ -97,231 +96,16 @@ public final class Http3ServerConnectionHandler extends ChannelInboundHandlerAda
             case BIDIRECTIONAL:
                 // Add the encoder and decoder in the pipeline so we can handle Http3Frames
                 pipeline.addLast(codecSupplier.get());
-                pipeline.addLast(new Http3RequestStreamValidationHandler());
+                pipeline.addLast(new Http3RequestStreamValidationHandler(true));
                 pipeline.addLast(requestStreamHandler);
                 break;
             case UNIDIRECTIONAL:
-                pipeline.addLast(new Http3ServerUnidirectionalStreamHandler(codecSupplier, controlStreamHandler));
+                pipeline.addLast(
+                        new Http3UnidirectionalStreamInboundHandler(true, codecSupplier, controlStreamHandler));
                 break;
             default:
                 throw new Error();
         }
         ctx.fireChannelRead(msg);
-    }
-
-    private static void readIfNoAutoRead(ChannelHandlerContext ctx) {
-        if (!ctx.channel().config().isAutoRead()) {
-            ctx.read();
-        }
-    }
-
-    private final class Http3ServerOutboundControlStreamHandler
-            extends Http3FrameTypeValidationHandler<Http3ControlStreamFrame> {
-        Http3ServerOutboundControlStreamHandler() {
-            super(Http3ControlStreamFrame.class);
-        }
-
-        @Override
-        public void channelActive(ChannelHandlerContext ctx) {
-            localControlStream = (QuicStreamChannel) ctx.channel();
-
-            // We need to write 0x00 into the stream before doing anything else.
-            // See https://tools.ietf.org/html/draft-ietf-quic-http-32#section-6.2.1
-            // Just allocate 8 bytes which would be the max needed.
-            ByteBuf buffer = ctx.alloc().directBuffer(8);
-            Http3CodecUtils.writeVariableLengthInteger(buffer, 0x00);
-            ctx.write(buffer);
-            // Add the encoder and decoder in the pipeline so we can handle Http3Frames
-            ctx.pipeline().addFirst(codecSupplier.get());
-            final Http3SettingsFrame settingsFrame;
-            if (localSettings == null) {
-                settingsFrame = new DefaultHttp3SettingsFrame();
-            } else {
-                settingsFrame = DefaultHttp3SettingsFrame.copyOf(localSettings);
-            }
-            // As we not support the dynamic table at the moment lets override whatever the user specified and set
-            // the capacity to 0.
-            settingsFrame.put(Http3Constants.SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0L);
-            // If writing of the local settings fails let's just teardown the connection.
-            localControlStream.writeAndFlush(settingsFrame)
-                    .addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
-
-            ctx.fireChannelActive();
-        }
-
-        @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt)  {
-            if (evt instanceof ChannelInputShutdownEvent) {
-                criticalStreamClosed(ctx);
-            }
-            ctx.fireUserEventTriggered(evt);
-        }
-
-        @Override
-        public void channelInactive(ChannelHandlerContext ctx) {
-            criticalStreamClosed(ctx);
-            ctx.fireChannelInactive();
-        }
-
-        // See https://tools.ietf.org/html/draft-ietf-quic-http-32#section-6.2.1
-        private void criticalStreamClosed(ChannelHandlerContext ctx) {
-            Http3CodecUtils.closeParent(
-                    ctx.channel(), Http3ErrorCode.H3_CLOSED_CRITICAL_STREAM, "Critical stream closed.");
-        }
-    }
-
-    private static final class Http3ServerUnidirectionalStreamHandler extends Http3UnidirectionalStreamHandler {
-        private final ChannelHandler controlStreamHandler;
-        private QuicStreamChannel remoteControlStream;
-        private QuicStreamChannel qpackEncoderStream;
-        private QuicStreamChannel qpackDecoderStream;
-
-        Http3ServerUnidirectionalStreamHandler(Supplier<Http3FrameCodec> codecSupplier,
-                                               ChannelHandler controlStreamHandler) {
-            super(codecSupplier);
-            this.controlStreamHandler = controlStreamHandler;
-        }
-
-        @Override
-        protected void initControlStream(QuicStreamChannel channel) {
-            if (remoteControlStream == null) {
-                remoteControlStream = channel;
-                channel.pipeline().addLast(new Http3FrameTypeValidationHandler<Http3ControlStreamFrame>(
-                        Http3ControlStreamFrame.class) {
-                    private boolean firstFrameRead;
-
-                    @Override
-                    public void channelRead(ChannelHandlerContext ctx,  Http3ControlStreamFrame frame) {
-                        final boolean firstFrame;
-                        if (!firstFrameRead) {
-                            firstFrameRead = true;
-                            firstFrame = true;
-                        } else {
-                            firstFrame = false;
-                        }
-                        if (frame instanceof Http3SettingsFrame) {
-                            // TODO: handle this.
-                            Http3SettingsFrame settingsFrame = (Http3SettingsFrame) frame;
-                            // As we not support dynamic table yet we dont create QPACK encoder / decoder streams.
-                            // Once we support dynamic table this should be done here as well.
-                            // TODO: Add QPACK stream creation.
-
-                        } else if (firstFrame) {
-                            // Only one control stream is allowed.
-                            // See https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-6.2.1
-                            Http3CodecUtils.closeParent(channel, Http3ErrorCode.H3_MISSING_SETTINGS,
-                                    "Missing settings frame.");
-                        } else {
-                            // TODO: Handle all other frames
-                        }
-                        if (controlStreamHandler != null) {
-                            // The user did specify ChannelHandler that should be notified about control stream frames.
-                            // Let's forward the frame so the user can do something with it.
-                            ctx.fireChannelRead(frame);
-                        } else {
-                            // We handled the frame, release it.
-                            ReferenceCountUtil.release(frame);
-                        }
-                    }
-
-                    @Override
-                    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-                        ctx.fireChannelReadComplete();
-
-                        // control streams should always be processed, no matter what the user is doing in terms of
-                        // configuration and AUTO_READ.
-                        readIfNoAutoRead(ctx);
-                    }
-                });
-                if (controlStreamHandler != null) {
-                    // The user want's to be notified about control frames, add the handler to the pipeline.
-                    channel.pipeline().addLast(controlStreamHandler);
-                }
-            } else {
-                // Only one control stream is allowed.
-                // See https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-6.2.1
-                Http3CodecUtils.closeParent(channel, Http3ErrorCode.H3_STREAM_CREATION_ERROR,
-                        "Received multiple control streams.");
-            }
-        }
-
-        @Override
-        protected void initPushStream(QuicStreamChannel channel, long id) {
-            Http3CodecUtils.closeParent(channel, Http3ErrorCode.H3_STREAM_CREATION_ERROR,
-                    "Server received push stream.");
-        }
-
-        @Override
-        protected void initQpackEncoderStream(QuicStreamChannel channel) {
-            if (qpackEncoderStream == null) {
-                qpackEncoderStream = channel;
-                // Just drop stuff on the floor as we dont support dynamic table atm.
-                channel.pipeline().addLast(QpackStreamHandler.INSTANCE);
-            } else {
-                // Only one stream is allowed.
-                // See https://www.ietf.org/archive/id/draft-ietf-quic-qpack-19.html#section-4.2
-                Http3CodecUtils.closeParent(channel, Http3ErrorCode.H3_STREAM_CREATION_ERROR,
-                        "Received multiple QPACK encoder streams.");
-            }
-        }
-
-        @Override
-        protected void initQpackDecoderStream(QuicStreamChannel channel) {
-            if (qpackDecoderStream == null) {
-                qpackDecoderStream = channel;
-                // Just drop stuff on the floor as we dont support dynamic table atm.
-                channel.pipeline().addLast(QpackStreamHandler.INSTANCE);
-            } else {
-                // Only one stream is allowed.
-                // See https://www.ietf.org/archive/id/draft-ietf-quic-qpack-19.html#section-4.2
-                Http3CodecUtils.closeParent(channel, Http3ErrorCode.H3_STREAM_CREATION_ERROR,
-                        "Received multiple QPACK decoder streams.");
-            }
-        }
-    }
-
-    private static final class QpackStreamHandler extends ChannelInboundHandlerAdapter {
-        static final QpackStreamHandler INSTANCE = new QpackStreamHandler();
-
-        private QpackStreamHandler() { }
-
-        @Override
-        public boolean isSharable() {
-            return true;
-        }
-
-        @Override
-        public void channelRead(ChannelHandlerContext ctx, Object msg) {
-            ReferenceCountUtil.release(msg);
-        }
-
-        @Override
-        public void channelReadComplete(ChannelHandlerContext ctx) {
-            ctx.fireChannelReadComplete();
-
-            // QPACK streams should always be processed, no matter what the user is doing in terms of configuration
-            // and AUTO_READ.
-            readIfNoAutoRead(ctx);
-        }
-
-        @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
-            if (evt instanceof ChannelInputShutdownEvent) {
-                criticalStreamClosed(ctx);
-            }
-            ctx.fireUserEventTriggered(evt);
-        }
-
-        @Override
-        public void channelInactive(ChannelHandlerContext ctx)  {
-            criticalStreamClosed(ctx);
-            ctx.fireChannelInactive();
-        }
-
-        // See https://www.ietf.org/archive/id/draft-ietf-quic-qpack-19.html#section-4.2
-        private void criticalStreamClosed(ChannelHandlerContext ctx) {
-            Http3CodecUtils.closeParent((QuicStreamChannel) ctx.channel(),
-                    Http3ErrorCode.H3_CLOSED_CRITICAL_STREAM, "Critical QPACK stream closed.");
-        }
     }
 }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3UnidirectionalStreamInboundHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3UnidirectionalStreamInboundHandler.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.incubator.codec.quic.QuicStreamChannel;
+
+import java.util.function.Supplier;
+
+final class Http3UnidirectionalStreamInboundHandler extends Http3UnidirectionalStreamHandler {
+    private final boolean server;
+    private final ChannelHandler controlStreamHandler;
+    private QuicStreamChannel remoteControlStream;
+    private QuicStreamChannel qpackEncoderStream;
+    private QuicStreamChannel qpackDecoderStream;
+
+    Http3UnidirectionalStreamInboundHandler(boolean server, Supplier<Http3FrameCodec> codecSupplier,
+                                            ChannelHandler controlStreamHandler) {
+        super(codecSupplier);
+        this.server = server;
+        this.controlStreamHandler = controlStreamHandler;
+    }
+
+    @Override
+    protected void initControlStream(QuicStreamChannel channel) {
+        if (remoteControlStream == null) {
+            remoteControlStream = channel;
+            boolean forwardControlStreamFrames = controlStreamHandler != null;
+            channel.pipeline().addLast(new Http3ControlStreamInboundHandler(server, forwardControlStreamFrames));
+            if (forwardControlStreamFrames) {
+                // The user want's to be notified about control frames, add the handler to the pipeline.
+                channel.pipeline().addLast(controlStreamHandler);
+            }
+        } else {
+            // Only one control stream is allowed.
+            // See https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-6.2.1
+            Http3CodecUtils.closeParent(channel, Http3ErrorCode.H3_STREAM_CREATION_ERROR,
+                    "Received multiple control streams.");
+        }
+    }
+
+    @Override
+    protected void initPushStream(QuicStreamChannel channel, long id) {
+        if (server) {
+            Http3CodecUtils.closeParent(channel, Http3ErrorCode.H3_STREAM_CREATION_ERROR,
+                    "Server received push stream.");
+        } else {
+            // TODO: Handle me
+        }
+    }
+
+    @Override
+    protected void initQpackEncoderStream(QuicStreamChannel channel) {
+        if (qpackEncoderStream == null) {
+            qpackEncoderStream = channel;
+            // Just drop stuff on the floor as we dont support dynamic table atm.
+            channel.pipeline().addLast(QpackStreamHandler.INSTANCE);
+        } else {
+            // Only one stream is allowed.
+            // See https://www.ietf.org/archive/id/draft-ietf-quic-qpack-19.html#section-4.2
+            Http3CodecUtils.closeParent(channel, Http3ErrorCode.H3_STREAM_CREATION_ERROR,
+                    "Received multiple QPACK encoder streams.");
+        }
+    }
+
+    @Override
+    protected void initQpackDecoderStream(QuicStreamChannel channel) {
+        if (qpackDecoderStream == null) {
+            qpackDecoderStream = channel;
+            // Just drop stuff on the floor as we dont support dynamic table atm.
+            channel.pipeline().addLast(QpackStreamHandler.INSTANCE);
+        } else {
+            // Only one stream is allowed.
+            // See https://www.ietf.org/archive/id/draft-ietf-quic-qpack-19.html#section-4.2
+            Http3CodecUtils.closeParent(channel, Http3ErrorCode.H3_STREAM_CREATION_ERROR,
+                    "Received multiple QPACK decoder streams.");
+        }
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/http3/QpackStreamHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackStreamHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.socket.ChannelInputShutdownEvent;
+import io.netty.incubator.codec.quic.QuicStreamChannel;
+import io.netty.util.ReferenceCountUtil;
+
+final class QpackStreamHandler extends ChannelInboundHandlerAdapter {
+    static final QpackStreamHandler INSTANCE = new QpackStreamHandler();
+
+    private QpackStreamHandler() {
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        ReferenceCountUtil.release(msg);
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.fireChannelReadComplete();
+
+        // QPACK streams should always be processed, no matter what the user is doing in terms of configuration
+        // and AUTO_READ.
+        Http3CodecUtils.readIfNoAutoRead(ctx);
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        if (evt instanceof ChannelInputShutdownEvent) {
+            criticalStreamClosed(ctx);
+        }
+        ctx.fireUserEventTriggered(evt);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        criticalStreamClosed(ctx);
+        ctx.fireChannelInactive();
+    }
+
+    // See https://www.ietf.org/archive/id/draft-ietf-quic-qpack-19.html#section-4.2
+    private void criticalStreamClosed(ChannelHandlerContext ctx) {
+        Http3CodecUtils.closeParent((QuicStreamChannel) ctx.channel(),
+                Http3ErrorCode.H3_CLOSED_CRITICAL_STREAM, "Critical QPACK stream closed.");
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamValidationHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamValidationHandlerTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.when;
 public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValidationHandlerTest {
     @Override
     protected Http3FrameTypeValidationHandler<Http3RequestStreamFrame> newValidationHandler() {
-        return new Http3RequestStreamValidationHandler();
+        return new Http3RequestStreamValidationHandler(true);
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Add basic validation for frames on the control stream and also correctly validate for push promise frames

Modifications:

- Add validation for control stream
- Refactor code to easier share between server and client (once client support is added)
- Move inner classes so its easier to test things etc

Result:

Better validation