### PR TITLE
Advertise the max header size via Http3SettingsFrame

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
@@ -23,6 +23,7 @@ import io.netty.incubator.codec.quic.QuicChannel;
 import io.netty.util.CharsetUtil;
 
 final class Http3CodecUtils {
+    static final long DEFAULT_MAX_HEADER_LIST_SIZE = 0xffffffffL;
 
     private Http3CodecUtils() { }
 


### PR DESCRIPTION
Motivation:

We should advertise the max header sizer via the Http3SettingsFrame so the remote peer knows what to expect.

Modifications:

Modify the Http3SettingsFrame if needed and advertise the max header size.

Result:

More conform to the spec