### PR TITLE
Fire exception through the pipeline when it makes sense before report…

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamOutboundHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamOutboundHandler.java
@@ -67,7 +67,7 @@ final class Http3ControlStreamOutboundHandler
 
     // See https://tools.ietf.org/html/draft-ietf-quic-http-32#section-6.2.1
     private void criticalStreamClosed(ChannelHandlerContext ctx) {
-        Http3CodecUtils.closeParent(
-                ctx.channel(), Http3ErrorCode.H3_CLOSED_CRITICAL_STREAM, "Critical stream closed.");
+        Http3CodecUtils.connectionError(
+                ctx, Http3ErrorCode.H3_CLOSED_CRITICAL_STREAM, "Critical stream closed.", false);
     }
 }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameDecoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameDecoder.java
@@ -173,13 +173,12 @@ final class Http3FrameDecoder extends ByteToMessageDecoder {
             // Throws exception if detected any problem so far
             sink.finish();
         } catch (Http3Exception e) {
-            Http3CodecUtils.closeParent(ctx.channel(), e.errorCode(), e.getMessage());
+            Http3CodecUtils.connectionError(ctx, e, true);
             return false;
         } catch (QpackException e) {
             // Must be treated as a connection error.
-            Http3CodecUtils.closeParent(
-                    ctx.channel(), Http3ErrorCode.QPACK_DECOMPRESSION_FAILED,
-                    "Decompression of header block failed.");
+            Http3CodecUtils.connectionError(ctx, Http3ErrorCode.QPACK_DECOMPRESSION_FAILED,
+                    "Decompression of header block failed.", true);
             return false;
         } catch (Http3HeadersValidationException e) {
             ctx.fireExceptionCaught(e);

--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandler.java
@@ -69,6 +69,6 @@ class Http3FrameTypeValidationHandler<T extends Http3Frame> extends ChannelDuple
 
     static void frameTypeUnexpected(ChannelHandlerContext ctx, Object frame) {
         ReferenceCountUtil.release(frame);
-        Http3CodecUtils.closeParent(ctx.channel(), Http3ErrorCode.H3_FRAME_UNEXPECTED, "Frame type unexpected");
+        Http3CodecUtils.connectionError(ctx, Http3ErrorCode.H3_FRAME_UNEXPECTED, "Frame type unexpected", true);
     }
 }

--- a/src/main/java/io/netty/incubator/codec/http3/QpackStreamHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackStreamHandler.java
@@ -18,7 +18,6 @@ package io.netty.incubator.codec.http3;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
-import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.util.ReferenceCountUtil;
 
 final class QpackStreamHandler extends ChannelInboundHandlerAdapter {
@@ -62,7 +61,7 @@ final class QpackStreamHandler extends ChannelInboundHandlerAdapter {
 
     // See https://www.ietf.org/archive/id/draft-ietf-quic-qpack-19.html#section-4.2
     private void criticalStreamClosed(ChannelHandlerContext ctx) {
-        Http3CodecUtils.closeParent((QuicStreamChannel) ctx.channel(),
-                Http3ErrorCode.H3_CLOSED_CRITICAL_STREAM, "Critical QPACK stream closed.");
+        Http3CodecUtils.connectionError(ctx,
+                Http3ErrorCode.H3_CLOSED_CRITICAL_STREAM, "Critical QPACK stream closed.", false);
     }
 }

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandlerTest.java
@@ -76,7 +76,11 @@ public class Http3FrameTypeValidationHandlerTest {
         EmbeddedChannel channel = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), true, false,
                 newValidationHandler());
         Http3ControlStreamFrame requestStreamFrame = new Http3ControlStreamFrame() { };
-        assertFalse(channel.writeInbound(requestStreamFrame));
+        try {
+            channel.writeInbound(requestStreamFrame);
+        } catch (Exception e) {
+            assertException(e);
+        }
         assertFalse(channel.finish());
         verify(parent).close(eq(true), eq(Http3ErrorCode.H3_FRAME_UNEXPECTED.code), argumentCaptor.capture());
         argumentCaptor.getValue().release();

--- a/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamValidationHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamValidationHandlerTest.java
@@ -55,7 +55,11 @@ public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValid
         EmbeddedChannel channel = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), true, false,
                 newValidationHandler());
         Http3DataFrame dataFrame = new DefaultHttp3DataFrame(Unpooled.buffer());
-        assertFalse(channel.writeInbound(dataFrame));
+        try {
+            channel.writeInbound(dataFrame);
+        } catch (Exception e) {
+            assertException(e);
+        }
         assertFalse(channel.finish());
         verify(parent).close(eq(true), eq(Http3ErrorCode.H3_FRAME_UNEXPECTED.code), argumentCaptor.capture());
         argumentCaptor.getValue().release();
@@ -75,19 +79,23 @@ public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValid
         Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
         Http3DataFrame dataFrame = new DefaultHttp3DataFrame(Unpooled.buffer());
         Http3DataFrame dataFrame2 = new DefaultHttp3DataFrame(Unpooled.buffer());
-        Http3DataFrame dat3Frame3 = new DefaultHttp3DataFrame(Unpooled.buffer());
+        Http3DataFrame dataFrame3 = new DefaultHttp3DataFrame(Unpooled.buffer());
         Http3HeadersFrame trailersFrame = new DefaultHttp3HeadersFrame();
 
         assertTrue(channel.writeInbound(headersFrame));
         assertTrue(channel.writeInbound(dataFrame.retainedDuplicate()));
         assertTrue(channel.writeInbound(dataFrame2.retainedDuplicate()));
         assertTrue(channel.writeInbound(trailersFrame));
-        assertTrue(channel.writeInbound(dat3Frame3));
+        try {
+            channel.writeInbound(dataFrame3);
+        } catch (Exception e) {
+            assertException(e);
+        }
 
         assertTrue(channel.finish());
         verify(parent).close(eq(true), eq(Http3ErrorCode.H3_FRAME_UNEXPECTED.code), argumentCaptor.capture());
         argumentCaptor.getValue().release();
-        assertEquals(0, dat3Frame3.refCnt());
+        assertEquals(0, dataFrame3.refCnt());
 
         assertFrame(headersFrame, channel.readInbound());
         assertFrame(dataFrame, channel.readInbound());


### PR DESCRIPTION
…ing back the connection error to the remote peer

Motivation:

If the user has a handler in the pipeline it makes sense to also let the user know about the exception that caused the connection error

Modifications:

- Change utility methods in Http3CodecUtils to also fire exceptions if needed
- Adjust tests

Result:

Easier for the user to understand why the connection was closed due a connection error