### PR TITLE
Allow to write Http3ControlStreamFrames also from the request stream

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
@@ -19,25 +19,12 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.incubator.codec.quic.QuicChannel;
-import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.util.CharsetUtil;
 
 final class Http3CodecUtils {
     static final long DEFAULT_MAX_HEADER_LIST_SIZE = 0xffffffffL;
 
     private Http3CodecUtils() { }
-
-    /**
-     * Returns the stream id for the local created control stream that is used by the HTTP 3 connection that this
-     * {@link QuicStreamChannel} is part of.
-     */
-    static long localControlStreamId(QuicStreamChannel channel) {
-        // The local control stream is always the first unidirectional stream we create.
-        if (channel.isLocalCreated()) {
-            return channel.streamId() % 2 == 0 ? 2 : 3;
-        }
-        return channel.streamId() % 2 == 0 ? 3 : 2;
-    }
 
     /**
      * Returns the number of bytes needed to encode the variable length integer.

--- a/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
@@ -19,12 +19,25 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.util.CharsetUtil;
 
 final class Http3CodecUtils {
     static final long DEFAULT_MAX_HEADER_LIST_SIZE = 0xffffffffL;
 
     private Http3CodecUtils() { }
+
+    /**
+     * Returns the stream id for the local created control stream that is used by the HTTP 3 connection that this
+     * {@link QuicStreamChannel} is part of.
+     */
+    static long localControlStreamId(QuicStreamChannel channel) {
+        // The local control stream is always the first unidirectional stream we create.
+        if (channel.isLocalCreated()) {
+            return channel.streamId() % 2 == 0 ? 2 : 3;
+        }
+        return channel.streamId() % 2 == 0 ? 3 : 2;
+    }
 
     /**
      * Returns the number of bytes needed to encode the variable length integer.

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamFrameDispatcher.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamFrameDispatcher.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.ChannelPromiseNotifier;
+import io.netty.incubator.codec.quic.QuicStreamChannel;
+
+import java.util.NoSuchElementException;
+
+/**
+ * {@link ChannelOutboundHandlerAdapter} which will intercept writes and dispatch {@link Http3ControlStreamFrame}s
+ * to the local control stream. This allows to write {@link Http3ControlStreamFrame}s also from other streams.
+ * that are no the control stream itself.
+ */
+final class Http3ControlStreamFrameDispatcher extends ChannelOutboundHandlerAdapter {
+
+    static final Http3ControlStreamFrameDispatcher INSTANCE = new Http3ControlStreamFrameDispatcher();
+
+    private Http3ControlStreamFrameDispatcher() { }
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+        if (msg instanceof Http3ControlStreamFrame) {
+            QuicStreamChannel channel = (QuicStreamChannel) ctx.channel();
+            long id = Http3CodecUtils.localControlStreamId(channel);
+            // Check if we are already on the local control frame or not.
+            if (id != channel.streamId()) {
+                Channel localControlStream = channel.parent().stream(id);
+                if (localControlStream == null) {
+                    promise.setFailure(new NoSuchElementException("Couldn't find control stream"));
+                } else {
+                    localControlStream.writeAndFlush(msg).addListener(new ChannelPromiseNotifier(promise));
+                }
+                return;
+            }
+        }
+        ctx.write(msg, promise);
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/http3/Http3RequestStreamInboundHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3RequestStreamInboundHandler.java
@@ -25,7 +25,7 @@ import io.netty.incubator.codec.quic.QuicStreamChannel;
  * {@link ChannelInboundHandlerAdapter} which makes it easy to handle
  * <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7">HTTP3 request streams</a>.
  */
-public abstract class Http3RequestStreamHandler extends ChannelInboundHandlerAdapter {
+public abstract class Http3RequestStreamInboundHandler extends ChannelInboundHandlerAdapter {
     private static final Http3DataFrame EMPTY = new DefaultHttp3DataFrame(Unpooled.EMPTY_BUFFER);
     private boolean lastFrameDetected;
     private boolean firstFrameReceived;

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
@@ -58,13 +58,14 @@ public final class Http3ServerConnectionHandler extends Http3ConnectionHandler {
     }
 
     @Override
-    void initBidirectionalStream(QuicStreamChannel channel, Supplier<Http3FrameCodec> codecSupplier) {
+    void initBidirectionalStream(QuicStreamChannel channel, Supplier<Http3FrameCodec> codecSupplier,
+                                 Http3ControlStreamFrameDispatcher dispatcher) {
         ChannelPipeline pipeline = channel.pipeline();
         // Add the encoder and decoder in the pipeline so we can handle Http3Frames
         pipeline.addLast(codecSupplier.get());
         pipeline.addLast(new Http3RequestStreamValidationHandler(true));
         // dispatch Http3ControlStreamFrames to the local control stream.
-        pipeline.addLast(Http3ControlStreamFrameDispatcher.INSTANCE);
+        pipeline.addLast(dispatcher);
         pipeline.addLast(requestStreamHandler);
     }
 }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
@@ -63,6 +63,8 @@ public final class Http3ServerConnectionHandler extends Http3ConnectionHandler {
         // Add the encoder and decoder in the pipeline so we can handle Http3Frames
         pipeline.addLast(codecSupplier.get());
         pipeline.addLast(new Http3RequestStreamValidationHandler(true));
+        // dispatch Http3ControlStreamFrames to the local control stream.
+        pipeline.addLast(Http3ControlStreamFrameDispatcher.INSTANCE);
         pipeline.addLast(requestStreamHandler);
     }
 }

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamFrameDispatcherTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamFrameDispatcherTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.channel.DefaultChannelId;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.incubator.codec.quic.QuicChannel;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class Http3ControlStreamFrameDispatcherTest {
+    @Test
+    public void testOnlyDispatchControlFrame() {
+        QuicChannel parent = mock(QuicChannel.class);
+
+        EmbeddedChannel channel = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), true, false,
+                Http3ControlStreamFrameDispatcher.INSTANCE);
+        Http3Frame frame = new Http3Frame() { };
+        Http3RequestStreamFrame requestStreamFrame = new Http3RequestStreamFrame() { };
+        Http3PushStreamFrame pushStreamFrame = new Http3PushStreamFrame() { };
+
+        assertTrue(channel.writeOutbound(frame));
+        assertTrue(channel.writeOutbound(requestStreamFrame));
+        assertTrue(channel.writeOutbound(pushStreamFrame));
+        assertSame(frame, channel.readOutbound());
+        assertSame(requestStreamFrame, channel.readOutbound());
+        assertSame(pushStreamFrame, channel.readOutbound());
+
+        assertFalse(channel.finish());
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ServerExample.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ServerExample.java
@@ -18,7 +18,6 @@ package io.netty.incubator.codec.http3;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
@@ -37,7 +36,6 @@ public final class Http3ServerExample {
     private Http3ServerExample() { }
 
     public static void main(String... args) throws Exception {
-
         NioEventLoopGroup group = new NioEventLoopGroup(1);
         ChannelHandler codec = Http3.newQuicServerCodecBuilder()
                 .certificateChain("./src/test/resources/cert.crt")
@@ -60,7 +58,7 @@ public final class Http3ServerExample {
                                     // Called for each request-stream,
                                     @Override
                                     protected void initChannel(QuicStreamChannel ch) {
-                                        ch.pipeline().addLast(new Http3RequestStreamHandler() {
+                                        ch.pipeline().addLast(new Http3RequestStreamInboundHandler() {
 
                                             @Override
                                             public void channelRead(ChannelHandlerContext ctx,


### PR DESCRIPTION
Motivation:

To make easier for users to write for example Http3GoAwayFrames we should allow to write control frames from the request stream as well.

Modifications:

- Add Http3ControlStreamFrameDispatcher which will find the local created control frame and delegate the frame to it.
- Add unit test

Result:

Be able to write control frames while on the request stream