### PR TITLE
Add tests for Http3ControlStreamInboundHandler

### DIFF
--- a/src/test/java/io/netty/incubator/codec/http3/AbstractHttp3FrameTypeValidationHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/AbstractHttp3FrameTypeValidationHandlerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.DefaultChannelId;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.util.ReferenceCounted;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+
+public abstract class AbstractHttp3FrameTypeValidationHandlerTest<T extends Http3Frame> {
+
+    protected abstract Http3FrameTypeValidationHandler<T> newHandler();
+
+    protected abstract List<T> newValidFrames();
+
+    protected abstract List<Http3Frame> newInvalidFrames();
+
+    @Test
+    public void testValidTypeInbound() {
+        EmbeddedChannel channel = new EmbeddedChannel(newHandler());
+        List<T> validFrames = newValidFrames();
+        for (T valid : validFrames) {
+            assertTrue(channel.writeInbound(valid));
+            T read = channel.readInbound();
+            assertSame(valid, read);
+        }
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testValidTypeOutput() {
+        EmbeddedChannel channel = new EmbeddedChannel(newHandler());
+        List<T> validFrames = newValidFrames();
+        for (T valid : validFrames) {
+            assertTrue(channel.writeOutbound(valid));
+            T read = channel.readOutbound();
+            assertSame(valid, read);
+        }
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testInvalidTypeInbound() {
+        QuicChannel parent = mockParent();
+        EmbeddedChannel channel = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), true, false,
+                newHandler());
+
+        List<Http3Frame> invalidFrames = newInvalidFrames();
+        for (Http3Frame invalid : invalidFrames) {
+            try {
+                channel.writeInbound(invalid);
+                fail();
+            } catch (Exception e) {
+                assertException(Http3ErrorCode.H3_FRAME_UNEXPECTED, e);
+            }
+            if (invalid instanceof ReferenceCounted) {
+                assertEquals(0, ((ReferenceCounted) invalid).refCnt());
+            }
+        }
+        verifyClose(invalidFrames.size(), Http3ErrorCode.H3_FRAME_UNEXPECTED, parent);
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testInvalidTypeOutput() {
+        EmbeddedChannel channel = new EmbeddedChannel(newHandler());
+
+        List<Http3Frame> invalidFrames = newInvalidFrames();
+        for (Http3Frame invalid : invalidFrames) {
+            try {
+                channel.writeOutbound(invalid);
+                fail();
+            } catch (Exception e) {
+                assertException(Http3ErrorCode.H3_FRAME_UNEXPECTED, e);
+            }
+            if (invalid instanceof ReferenceCounted) {
+                assertEquals(0, ((ReferenceCounted) invalid).refCnt());
+            }
+        }
+        assertFalse(channel.finish());
+    }
+
+    protected static void assertException(Http3ErrorCode code, Exception e) {
+        MatcherAssert.assertThat(e, CoreMatchers.instanceOf(Http3Exception.class));
+        Http3Exception exception = (Http3Exception) e;
+        assertEquals(code, exception.errorCode());
+    }
+
+    protected void verifyClose(Http3ErrorCode expectedCode, QuicChannel parent) {
+        verifyClose(1, expectedCode, parent);
+    }
+
+    protected void verifyClose(int times, Http3ErrorCode expectedCode, QuicChannel parent) {
+        ArgumentCaptor<ByteBuf> argumentCaptor = ArgumentCaptor.forClass(ByteBuf.class);
+        try {
+            verify(parent, times(times)).close(eq(true),
+                    eq(expectedCode.code), argumentCaptor.capture());
+        } finally {
+            for (ByteBuf buffer : argumentCaptor.getAllValues()) {
+                buffer.release();
+            }
+        }
+    }
+
+    protected static QuicChannel mockParent() {
+        QuicChannel parent = mock(QuicChannel.class);
+        when(parent.close(anyBoolean(), anyInt(),
+                any(ByteBuf.class))).thenReturn(new DefaultChannelPromise(parent));
+        when(parent.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
+        return parent;
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamInboundHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamInboundHandlerTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.channel.DefaultChannelId;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ReferenceCounted;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+@RunWith(Parameterized.class)
+public class Http3ControlStreamInboundHandlerTest extends
+        AbstractHttp3FrameTypeValidationHandlerTest<Http3ControlStreamFrame> {
+
+    private final boolean server;
+    private final boolean forwardControlFrames;
+
+    public Http3ControlStreamInboundHandlerTest(boolean server, boolean forwardControlFrames) {
+        this.server = server;
+        this.forwardControlFrames = forwardControlFrames;
+    }
+
+    @Parameterized.Parameters(name = "{index}: server = {0}, forwardControlFrames = {1}")
+    public static Collection<Object[]> data() {
+        List<Object[]> config = new ArrayList<>();
+        for (int a = 0; a < 2; a++) {
+            for (int b = 0; b < 2; b++) {
+                config.add(new Object[] { a == 0, b == 0 });
+            }
+        }
+        return config;
+    }
+
+    @Override
+    protected Http3FrameTypeValidationHandler<Http3ControlStreamFrame> newHandler() {
+        return new Http3ControlStreamInboundHandler(true, true);
+    }
+
+    @Override
+    protected List<Http3ControlStreamFrame> newValidFrames() {
+        return Arrays.asList(new DefaultHttp3SettingsFrame(), new DefaultHttp3GoAwayFrame(0),
+                new DefaultHttp3MaxPushIdFrame(0), new DefaultHttp3CancelPushFrame(0));
+    }
+
+    @Override
+    protected List<Http3Frame> newInvalidFrames() {
+        return Arrays.asList(new Http3RequestStreamFrame() { }, new Http3PushStreamFrame() { });
+    }
+
+    @Test
+    public void testInvalidFirstFrameHttp3GoAwayFrame() {
+        testInvalidFirstFrame(new DefaultHttp3GoAwayFrame(0));
+    }
+
+    @Test
+    public void testInvalidFirstFrameHttp3MaxPushIdFrame() {
+        testInvalidFirstFrame(new DefaultHttp3MaxPushIdFrame(0));
+    }
+
+    @Test
+    public void testInvalidFirstFrameHttp3CancelPushFrame() {
+        testInvalidFirstFrame(new DefaultHttp3CancelPushFrame(0));
+    }
+
+    private void testInvalidFirstFrame(Http3ControlStreamFrame controlStreamFrame) {
+        QuicChannel parent = mockParent();
+        EmbeddedChannel channel = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), true, false,
+                new Http3ControlStreamInboundHandler(server, forwardControlFrames));
+
+        writeInvalidFrame(Http3ErrorCode.H3_MISSING_SETTINGS, channel, controlStreamFrame);
+        verifyClose(Http3ErrorCode.H3_MISSING_SETTINGS, parent);
+
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testValidGoAwayFrame() {
+        QuicChannel parent = mock(QuicChannel.class);
+        EmbeddedChannel channel = newInitChannel(parent);
+        writeValidFrame(channel, new DefaultHttp3GoAwayFrame(0));
+        writeValidFrame(channel, new DefaultHttp3GoAwayFrame(0));
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testSecondGoAwayFrameFailsWithHigherId() {
+        QuicChannel parent = mockParent();
+        EmbeddedChannel channel = newInitChannel(parent);
+        writeValidFrame(channel, new DefaultHttp3GoAwayFrame(0));
+        writeInvalidFrame(Http3ErrorCode.H3_ID_ERROR, channel, new DefaultHttp3GoAwayFrame(4));
+        verifyClose(Http3ErrorCode.H3_ID_ERROR, parent);
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testGoAwayFrameIdNonRequestStream() {
+        QuicChannel parent = mockParent();
+        EmbeddedChannel channel = newInitChannel(parent);
+        if (server) {
+            writeValidFrame(channel, new DefaultHttp3GoAwayFrame(3));
+        } else {
+            writeInvalidFrame(Http3ErrorCode.H3_FRAME_UNEXPECTED, channel, new DefaultHttp3GoAwayFrame(3));
+            verifyClose(Http3ErrorCode.H3_FRAME_UNEXPECTED, parent);
+        }
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testHttp3MaxPushIdFrames() {
+        QuicChannel parent = mockParent();
+        EmbeddedChannel channel = newInitChannel(parent);
+        if (server) {
+            writeValidFrame(channel, new DefaultHttp3MaxPushIdFrame(0));
+            writeValidFrame(channel, new DefaultHttp3MaxPushIdFrame(4));
+        } else {
+            writeInvalidFrame(Http3ErrorCode.H3_FRAME_UNEXPECTED, channel, new DefaultHttp3MaxPushIdFrame(4));
+            verifyClose(Http3ErrorCode.H3_FRAME_UNEXPECTED, parent);
+        }
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testSecondHttp3MaxPushIdFrameFailsWithSmallerId() {
+        if (!server) {
+            return;
+        }
+        QuicChannel parent = mockParent();
+        EmbeddedChannel channel = newInitChannel(parent);
+        writeValidFrame(channel, new DefaultHttp3MaxPushIdFrame(4));
+        writeInvalidFrame(Http3ErrorCode.H3_ID_ERROR, channel, new DefaultHttp3MaxPushIdFrame(0));
+        verifyClose(Http3ErrorCode.H3_ID_ERROR, parent);
+        assertFalse(channel.finish());
+    }
+
+    private EmbeddedChannel newInitChannel(QuicChannel parent) {
+        EmbeddedChannel channel = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), true, false,
+                new Http3ControlStreamInboundHandler(server, forwardControlFrames));
+
+        // We always need to start with a settings frame.
+        Http3SettingsFrame settingsFrame = new DefaultHttp3SettingsFrame();
+        assertEquals(forwardControlFrames, channel.writeInbound(settingsFrame));
+        if (forwardControlFrames) {
+            assertSame(settingsFrame, channel.readInbound());
+        }
+        return channel;
+    }
+
+    private void writeValidFrame(EmbeddedChannel channel, Http3ControlStreamFrame controlStreamFrame) {
+        assertEquals(forwardControlFrames, channel.writeInbound(controlStreamFrame));
+        if (forwardControlFrames) {
+            assertSame(controlStreamFrame, channel.readInbound());
+            ReferenceCountUtil.release(controlStreamFrame);
+        } else {
+            if (controlStreamFrame instanceof ReferenceCounted) {
+                assertEquals(0, ((ReferenceCounted) controlStreamFrame).refCnt());
+            }
+        }
+    }
+
+    private void writeInvalidFrame(Http3ErrorCode expectedCode, EmbeddedChannel channel,
+                                   Http3ControlStreamFrame controlStreamFrame) {
+        if (forwardControlFrames) {
+            try {
+                channel.writeInbound(controlStreamFrame);
+                fail();
+            } catch (Exception e) {
+                assertException(expectedCode, e);
+            }
+        } else {
+            assertFalse(channel.writeInbound(controlStreamFrame));
+            if (controlStreamFrame instanceof ReferenceCounted) {
+                assertEquals(0, ((ReferenceCounted) controlStreamFrame).refCnt());
+            }
+        }
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameEncoderDecoderTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameEncoderDecoderTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class Http3FrameEncoderDecoderTest {
 
-    @Parameterized.Parameters
+    @Parameterized.Parameters(name = "{index}: fragmented = {0}")
     public static Object[] parameters() {
         return new Object[] { false, true };
     }

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandlerTest.java
@@ -15,93 +15,25 @@
  */
 package io.netty.incubator.codec.http3;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.UnpooledByteBufAllocator;
-import io.netty.channel.DefaultChannelId;
-import io.netty.channel.DefaultChannelPromise;
-import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.incubator.codec.quic.QuicChannel;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+public class Http3FrameTypeValidationHandlerTest extends
+        AbstractHttp3FrameTypeValidationHandlerTest<Http3RequestStreamFrame> {
 
-public class Http3FrameTypeValidationHandlerTest {
-
-    protected Http3FrameTypeValidationHandler<Http3RequestStreamFrame> newValidationHandler() {
+    @Override
+    protected Http3FrameTypeValidationHandler<Http3RequestStreamFrame> newHandler() {
         return new Http3FrameTypeValidationHandler<>(Http3RequestStreamFrame.class);
     }
 
-    @Test
-    public void testValidTypeInbound() {
-        EmbeddedChannel channel = new EmbeddedChannel(newValidationHandler());
-
-        Http3RequestStreamFrame requestStreamFrame = new DefaultHttp3HeadersFrame();
-        assertTrue(channel.writeInbound(requestStreamFrame));
-        Http3RequestStreamFrame read = channel.readInbound();
-        assertEquals(requestStreamFrame, read);
-        assertFalse(channel.finish());
+    @Override
+    protected List<Http3RequestStreamFrame> newValidFrames() {
+        return Collections.singletonList(new Http3RequestStreamFrame() { });
     }
 
-    @Test
-    public void testValidTypeOutput() {
-        EmbeddedChannel channel = new EmbeddedChannel(newValidationHandler());
-
-        Http3RequestStreamFrame requestStreamFrame = new DefaultHttp3HeadersFrame();
-        assertTrue(channel.writeOutbound(requestStreamFrame));
-        Http3RequestStreamFrame read = channel.readOutbound();
-        assertEquals(requestStreamFrame, read);
-        assertFalse(channel.finish());
-    }
-
-    @Test
-    public void testInvalidTypeInbound() {
-        QuicChannel parent = mock(QuicChannel.class);
-        ArgumentCaptor<ByteBuf> argumentCaptor = ArgumentCaptor.forClass(ByteBuf.class);
-        when(parent.close(anyBoolean(), anyInt(),
-                any(ByteBuf.class))).thenReturn(new DefaultChannelPromise(parent));
-        when(parent.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
-
-        EmbeddedChannel channel = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), true, false,
-                newValidationHandler());
-        Http3ControlStreamFrame requestStreamFrame = new Http3ControlStreamFrame() { };
-        try {
-            channel.writeInbound(requestStreamFrame);
-        } catch (Exception e) {
-            assertException(e);
-        }
-        assertFalse(channel.finish());
-        verify(parent).close(eq(true), eq(Http3ErrorCode.H3_FRAME_UNEXPECTED.code), argumentCaptor.capture());
-        argumentCaptor.getValue().release();
-    }
-
-    @Test
-    public void testInvalidTypeOutput() {
-        EmbeddedChannel channel = new EmbeddedChannel(newValidationHandler());
-
-        Http3ControlStreamFrame requestStreamFrame = new Http3ControlStreamFrame() { };
-        try {
-            channel.writeOutbound(requestStreamFrame);
-        } catch (Exception e) {
-            assertException(e);
-        }
-        assertFalse(channel.finish());
-    }
-
-    protected static void assertException(Exception e) {
-        MatcherAssert.assertThat(e, CoreMatchers.instanceOf(Http3Exception.class));
-        Http3Exception exception = (Http3Exception) e;
-        assertEquals(Http3ErrorCode.H3_FRAME_UNEXPECTED, exception.errorCode());
+    @Override
+    protected List<Http3Frame> newInvalidFrames() {
+        return Arrays.asList(new Http3ControlStreamFrame() { }, new Http3PushStreamFrame() { });
     }
 }


### PR DESCRIPTION
Motivation:

Http3ControlStreamInboundHandler needs tests and also we can add a few more tests for others.

Modifications:

Add Http3ControlStreamInboundHandlerTest and fix a bug related to handling Http3GoAwayFrames

Result:

More tests and less bugs