### PR TITLE
Add tests for Http3ControlStreamOutboundHandler and QpackStreamHandler

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
@@ -133,6 +133,14 @@ final class Http3CodecUtils {
         return 1;
     }
 
+    static void criticalStreamClosed(ChannelHandlerContext ctx) {
+        if (ctx.channel().parent().isActive()) {
+            // Stream was closed while the parent channel is still active
+            Http3CodecUtils.connectionError(
+                    ctx, Http3ErrorCode.H3_CLOSED_CRITICAL_STREAM, "Critical stream closed.", false);
+        }
+    }
+
     /**
      * A connection-error should be handled as defined in the HTTP3 spec.
      * @param ctx           the {@link ChannelHandlerContext} of the handle that handles it.

--- a/src/main/java/io/netty/incubator/codec/http3/QpackStreamHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackStreamHandler.java
@@ -48,20 +48,16 @@ final class QpackStreamHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
         if (evt instanceof ChannelInputShutdownEvent) {
-            criticalStreamClosed(ctx);
+            // See https://www.ietf.org/archive/id/draft-ietf-quic-qpack-19.html#section-4.2
+            Http3CodecUtils.criticalStreamClosed(ctx);
         }
         ctx.fireUserEventTriggered(evt);
     }
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) {
-        criticalStreamClosed(ctx);
+        // See https://www.ietf.org/archive/id/draft-ietf-quic-qpack-19.html#section-4.2
+        Http3CodecUtils.criticalStreamClosed(ctx);
         ctx.fireChannelInactive();
-    }
-
-    // See https://www.ietf.org/archive/id/draft-ietf-quic-qpack-19.html#section-4.2
-    private void criticalStreamClosed(ChannelHandlerContext ctx) {
-        Http3CodecUtils.connectionError(ctx,
-                Http3ErrorCode.H3_CLOSED_CRITICAL_STREAM, "Critical QPACK stream closed.", false);
     }
 }

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamOutboundHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamOutboundHandlerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.incubator.codec.quic.QuicChannel;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static io.netty.incubator.codec.http3.Http3TestUtils.mockParent;
+import static io.netty.incubator.codec.http3.Http3TestUtils.verifyClose;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class Http3ControlStreamOutboundHandlerTest extends
+        AbstractHttp3FrameTypeValidationHandlerTest<Http3ControlStreamFrame> {
+    private final Http3SettingsFrame settingsFrame = new DefaultHttp3SettingsFrame();
+
+    @Override
+    protected Http3FrameTypeValidationHandler<Http3ControlStreamFrame> newHandler() {
+        return new Http3ControlStreamOutboundHandler(settingsFrame, ChannelInboundHandlerAdapter::new);
+    }
+
+    @Override
+    protected List<Http3ControlStreamFrame> newValidFrames() {
+        return Arrays.asList(new DefaultHttp3SettingsFrame(), new DefaultHttp3GoAwayFrame(0),
+                new DefaultHttp3MaxPushIdFrame(0), new DefaultHttp3CancelPushFrame(0));
+    }
+
+    @Override
+    protected List<Http3Frame> newInvalidFrames() {
+        return Arrays.asList(new Http3RequestStreamFrame() { }, new Http3PushStreamFrame() { });
+    }
+
+    @Test
+    public void testStreamClosedWhileParentStillActive() {
+        QuicChannel parent = mockParent();
+        EmbeddedChannel channel = newChannel(parent, newHandler(), true);
+        assertFalse(channel.finish());
+        verifyClose(1, Http3ErrorCode.H3_CLOSED_CRITICAL_STREAM, parent);
+    }
+
+    @Override
+    protected EmbeddedChannel newChannel(Channel parent,
+                                         Http3FrameTypeValidationHandler<Http3ControlStreamFrame> handler) {
+        if (parent == null) {
+            parent = Mockito.mock(QuicChannel.class);
+        }
+        return newChannel(parent, handler, false);
+    }
+
+    private EmbeddedChannel newChannel(Channel parent, Http3FrameTypeValidationHandler<Http3ControlStreamFrame> handler,
+                                       boolean parentActive) {
+        Mockito.when(parent.isActive()).thenReturn(parentActive);
+
+        EmbeddedChannel channel = super.newChannel(parent, handler);
+        ByteBuf buffer = channel.readOutbound();
+        // Verify that we did write the control stream prefix
+        int len = Http3CodecUtils.numBytesForVariableLengthInteger(buffer.getByte(0));
+        assertEquals(0x00, Http3CodecUtils.readVariableLengthInteger(buffer, len));
+        assertFalse(buffer.isReadable());
+        buffer.release();
+
+        Http3SettingsFrame settings = channel.readOutbound();
+        assertSame(settingsFrame, settings);
+
+        assertNull(channel.readOutbound());
+        return channel;
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameEncoderDecoderTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameEncoderDecoderTest.java
@@ -21,7 +21,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.util.ReferenceCountUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -163,9 +162,7 @@ public class Http3FrameEncoderDecoderTest {
             assertTrue(decoderChannel.writeInbound(buffer));
         }
         Http3Frame readFrame = decoderChannel.readInbound();
-        assertEquals(frame, readFrame);
-        ReferenceCountUtil.release(readFrame);
-        ReferenceCountUtil.release(frame);
+        Http3TestUtils.assertFrameEquals(frame, readFrame);
         assertFalse(encoderChannel.finish());
         assertFalse(decoderChannel.finish());
     }

--- a/src/test/java/io/netty/incubator/codec/http3/Http3TestUtils.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3TestUtils.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ReferenceCounted;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+final class Http3TestUtils {
+
+    private Http3TestUtils() { }
+
+    static QuicChannel mockParent() {
+        QuicChannel parent = mock(QuicChannel.class);
+        when(parent.close(anyBoolean(), anyInt(),
+                any(ByteBuf.class))).thenReturn(new DefaultChannelPromise(parent));
+        when(parent.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
+        return parent;
+    }
+
+    static void assertException(Http3ErrorCode code, Exception e) {
+        MatcherAssert.assertThat(e, CoreMatchers.instanceOf(Http3Exception.class));
+        Http3Exception exception = (Http3Exception) e;
+        assertEquals(code, exception.errorCode());
+    }
+
+    static void verifyClose(Http3ErrorCode expectedCode, QuicChannel parent) {
+        verifyClose(1, expectedCode, parent);
+    }
+
+    static void verifyClose(int times, Http3ErrorCode expectedCode, QuicChannel parent) {
+        ArgumentCaptor<ByteBuf> argumentCaptor = ArgumentCaptor.forClass(ByteBuf.class);
+        try {
+            verify(parent, times(times)).close(eq(true),
+                    eq(expectedCode.code), argumentCaptor.capture());
+        } finally {
+            for (ByteBuf buffer : argumentCaptor.getAllValues()) {
+                buffer.release();
+            }
+        }
+    }
+
+    static void assertFrameEquals(Http3Frame expected, Http3Frame actual) {
+        try {
+            assertEquals(expected, actual);
+        } finally {
+            ReferenceCountUtil.release(expected);
+            ReferenceCountUtil.release(actual);
+        }
+    }
+
+    static void assertFrameSame(Http3Frame expected, Http3Frame actual) {
+        try {
+            assertSame(expected, actual);
+        } finally {
+            // as both frames are the same we only want to release once.
+            ReferenceCountUtil.release(actual);
+        }
+    }
+
+    static void assertFrameReleased(Http3Frame frame) {
+        if (frame instanceof ReferenceCounted) {
+            assertEquals(0, ((ReferenceCounted) frame).refCnt());
+        }
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/QpackStreamHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackStreamHandlerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.DefaultChannelId;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.incubator.codec.quic.QuicChannel;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static io.netty.incubator.codec.http3.Http3TestUtils.mockParent;
+import static io.netty.incubator.codec.http3.Http3TestUtils.verifyClose;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class QpackStreamHandlerTest {
+
+    @Test
+    public void testStreamClosedWhileParentStillActive() {
+        QuicChannel parent = mockParent();
+        Mockito.when(parent.isActive()).thenReturn(true);
+        EmbeddedChannel channel = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), true,
+                false, QpackStreamHandler.INSTANCE);
+        assertFalse(channel.finish());
+        verifyClose(1, Http3ErrorCode.H3_CLOSED_CRITICAL_STREAM, parent);
+    }
+
+    @Test
+    public void testStreamClosedWhileParentIsInactive() {
+        QuicChannel parent = mockParent();
+        Mockito.when(parent.isActive()).thenReturn(false);
+        EmbeddedChannel channel = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), true,
+                false, QpackStreamHandler.INSTANCE);
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testStreamDropsInboundData() {
+        QuicChannel parent = mockParent();
+        Mockito.when(parent.isActive()).thenReturn(false);
+        EmbeddedChannel channel = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), true,
+                false, QpackStreamHandler.INSTANCE);
+        ByteBuf buffer = Unpooled.buffer();
+        assertFalse(channel.writeInbound(buffer));
+        assertEquals(0, buffer.refCnt());
+        assertFalse(channel.finish());
+    }
+}


### PR DESCRIPTION
Motivation:

We should test Http3ControlStreamOutboundHandler and QpackStreamHandler

Modifications:

- Add tests for both
- Move common used test stuff into Http3TestUtils
- Change Http3ControlStreamOutboundHandler constructor to be more flexible and so make testing easier
- Fix detection of closure of critical stream

Result:

More tests and handle correctly the detection of closing critical streams