### PR TITLE
Netty 4.1.55.Final is out, we should use it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
   <properties>
     <javaModuleName>io.netty.incubator.codec.http3</javaModuleName>
     <skipTests>false</skipTests>
-    <netty.version>4.1.54.Final</netty.version>
+    <netty.version>4.1.55.Final</netty.version>
     <netty.build.version>28</netty.build.version>
     <netty.quic.version>0.0.1.Final-SNAPSHOT</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>


### PR DESCRIPTION
Motivation:

We just had a new netty release.

Modifications:

Update dependency netty version to 4.1.55.Final

Result:

Use latest version