### PR TITLE
Fixup javadocs

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/DefaultHttp3SettingsFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/DefaultHttp3SettingsFrame.java
@@ -32,8 +32,8 @@ public final class DefaultHttp3SettingsFrame implements Http3SettingsFrame {
     }
 
     @Override
-    public void put(long key, Long value) {
-        settings.put(key, value);
+    public Long put(long key, Long value) {
+        return settings.put(key, value);
     }
 
     @Override

--- a/src/main/java/io/netty/incubator/codec/http3/Http3.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3.java
@@ -33,6 +33,11 @@ public final class Http3 {
             0x05, 'h', '3', '-', '3', '2'
     };
 
+    /**
+     * Returns the supported protocols for H3.
+     *
+     * @return the supported protocols.
+     */
     public static byte[] supportedApplicationProtocols() {
         return H3_PROTOS.clone();
     }
@@ -52,6 +57,8 @@ public final class Http3 {
 
     /**
      * Returns a new {@link QuicServerCodecBuilder} that has preconfigured for HTTP3.
+     *
+     * @return a pre-configured builder for HTTP3.
      */
     public static QuicServerCodecBuilder newQuicServerCodecBuilder() {
         return configure(new QuicServerCodecBuilder());
@@ -59,6 +66,8 @@ public final class Http3 {
 
     /**
      * Returns a new {@link QuicClientCodecBuilder} that has preconfigured for HTTP3.
+     *
+     * @return a pre-configured builder for HTTP3.
      */
     public static QuicClientCodecBuilder newQuicClientCodecBuilder() {
         return configure(new QuicClientCodecBuilder());

--- a/src/main/java/io/netty/incubator/codec/http3/Http3CancelPushFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3CancelPushFrame.java
@@ -16,12 +16,14 @@
 package io.netty.incubator.codec.http3;
 
 /**
- * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.3>CANCEL_PUSH</a>.
+ * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.3">CANCEL_PUSH</a>.
  */
 public interface Http3CancelPushFrame extends Http3ControlStreamFrame {
 
     /**
      * Returns the push id that identifies the server push that is being cancelled.
+     *
+     * @return the id.
      */
     long id();
 }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3Constants.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3Constants.java
@@ -20,13 +20,13 @@ public final class Http3Constants {
     private Http3Constants() { }
 
     /**
-     * See <a href=https://tools.ietf.org/html/draft-ietf-quic-qpack-19#section-5">
+     * See <a href="https://tools.ietf.org/html/draft-ietf-quic-qpack-19#section-5">
      *     SETTINGS_QPACK_MAX_TABLE_CAPACITY</a>.
      */
     public static final long SETTINGS_QPACK_MAX_TABLE_CAPACITY = 0x1;
 
     /**
-     * See <a href=https://tools.ietf.org/html/draft-ietf-quic-qpack-19#section-5">
+     * See <a href="https://tools.ietf.org/html/draft-ietf-quic-qpack-19#section-5">
      *     SETTINGS_QPACK_BLOCKED_STREAMS</a>.
      */
     public static final long SETTINGS_QPACK_BLOCKED_STREAMS = 0x7;

--- a/src/main/java/io/netty/incubator/codec/http3/Http3DataFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3DataFrame.java
@@ -19,7 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 
 /**
- * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.1>DATA</a>.
+ * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.1">DATA</a>.
  */
 public interface Http3DataFrame extends ByteBufHolder, Http3RequestStreamFrame, Http3PushStreamFrame {
 

--- a/src/main/java/io/netty/incubator/codec/http3/Http3Exception.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3Exception.java
@@ -23,11 +23,24 @@ import io.netty.util.internal.ObjectUtil;
 public final class Http3Exception extends Exception {
     private final Http3ErrorCode errorCode;
 
+    /**
+     * Create a new instance.
+     *
+     * @param errorCode the {@link Http3ErrorCode} that caused this exception.
+     * @param message   the message to include.
+     */
     public Http3Exception(Http3ErrorCode errorCode, String message) {
         super(message);
         this.errorCode = ObjectUtil.checkNotNull(errorCode, "errorCode");
     }
 
+    /**
+     * Create a new instance.
+     *
+     * @param errorCode the {@link Http3ErrorCode} that caused this exception.
+     * @param message   the message to include.
+     * @param cause     the {@link Throwable} to wrap.
+     */
     public Http3Exception(Http3ErrorCode errorCode, String message, Throwable cause) {
         super(message, cause);
         this.errorCode = ObjectUtil.checkNotNull(errorCode, "errorCode");
@@ -35,6 +48,8 @@ public final class Http3Exception extends Exception {
 
     /**
      * Returns the related {@link Http3ErrorCode}.
+     *
+     * @return the {@link Http3ErrorCode}.
      */
     public Http3ErrorCode errorCode() {
         return errorCode;

--- a/src/main/java/io/netty/incubator/codec/http3/Http3GoAwayFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3GoAwayFrame.java
@@ -16,12 +16,14 @@
 package io.netty.incubator.codec.http3;
 
 /**
- * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.6>GOAWAY</a>.
+ * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.6">GOAWAY</a>.
  */
 public interface Http3GoAwayFrame extends Http3ControlStreamFrame {
 
     /**
      * Returns the id.
+     *
+     * @return the id.
      */
     long id();
 }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3Headers.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3Headers.java
@@ -78,7 +78,8 @@ public interface Http3Headers extends Headers<CharSequence, CharSequence, Http3H
         /**
          * Indicates whether the specified header follows the pseudo-header format (begins with ':' character)
          *
-         * @return {@code true} if the header follow the pseudo-header format
+         * @param headerName    the header name to check.
+         * @return              {@code true} if the header follow the pseudo-header format
          */
         public static boolean hasPseudoHeaderFormat(CharSequence headerName) {
             if (headerName instanceof AsciiString) {
@@ -90,19 +91,23 @@ public interface Http3Headers extends Headers<CharSequence, CharSequence, Http3H
         }
 
         /**
-         * Indicates whether the given header name is a valid HTTP/2 pseudo header.
+         * Indicates whether the given header name is a valid HTTP/3 pseudo header.
+         *
+         * @param name  the header name.
+         * @return      {@code true} if the given header name is a valid HTTP/3 pseudo header, {@code false} otherwise.
          */
-        public static boolean isPseudoHeader(CharSequence header) {
-            return PSEUDO_HEADERS.contains(header);
+        public static boolean isPseudoHeader(CharSequence name) {
+            return PSEUDO_HEADERS.contains(name);
         }
 
         /**
          * Returns the {@link PseudoHeaderName} corresponding to the specified header name.
          *
+         * @param name  the header name.
          * @return corresponding {@link PseudoHeaderName} if any, {@code null} otherwise.
          */
-        public static PseudoHeaderName getPseudoHeader(CharSequence header) {
-            return PSEUDO_HEADERS.get(header);
+        public static PseudoHeaderName getPseudoHeader(CharSequence name) {
+            return PSEUDO_HEADERS.get(name);
         }
 
         /**
@@ -132,51 +137,76 @@ public interface Http3Headers extends Headers<CharSequence, CharSequence, Http3H
 
     /**
      * Sets the {@link PseudoHeaderName#METHOD} header
+     *
+     * @param value the value for the header.
+     * @return      this instance itself.
      */
     Http3Headers method(CharSequence value);
 
     /**
      * Sets the {@link PseudoHeaderName#SCHEME} header
+     *
+     * @param value the value for the header.
+     * @return      this instance itself.
      */
     Http3Headers scheme(CharSequence value);
 
     /**
      * Sets the {@link PseudoHeaderName#AUTHORITY} header
+     *
+     * @param value the value for the header.
+     * @return      this instance itself.
      */
     Http3Headers authority(CharSequence value);
 
     /**
      * Sets the {@link PseudoHeaderName#PATH} header
+     *
+     * @param value the value for the header.
+     * @return      this instance itself.
      */
     Http3Headers path(CharSequence value);
 
     /**
      * Sets the {@link PseudoHeaderName#STATUS} header
+     *
+     * @param value the value for the header.
+     * @return      this instance itself.
      */
     Http3Headers status(CharSequence value);
 
     /**
      * Gets the {@link PseudoHeaderName#METHOD} header or {@code null} if there is no such header
+     *
+     * @return the value of the header.
      */
     CharSequence method();
 
     /**
      * Gets the {@link PseudoHeaderName#SCHEME} header or {@code null} if there is no such header
+     *
+     * @return the value of the header.
      */
     CharSequence scheme();
 
     /**
      * Gets the {@link PseudoHeaderName#AUTHORITY} header or {@code null} if there is no such header
+     *
+     * @return the value of the header.
      */
     CharSequence authority();
 
     /**
      * Gets the {@link PseudoHeaderName#PATH} header or {@code null} if there is no such header
+     *
+     * @return the value of the header.
      */
     CharSequence path();
 
     /**
      * Gets the {@link PseudoHeaderName#STATUS} header or {@code null} if there is no such header
+     *
+     * @return the value of the header.
      */
     CharSequence status();
 
@@ -185,10 +215,11 @@ public interface Http3Headers extends Headers<CharSequence, CharSequence, Http3H
      * <p>
      * If {@code caseInsensitive} is {@code true} then a case insensitive compare is done on the value.
      *
-     * @param name the name of the header to find
-     * @param value the value of the header to find
-     * @param caseInsensitive {@code true} then a case insensitive compare is run to compare values.
+     * @param name              the name of the header to find
+     * @param value             the value of the header to find
+     * @param caseInsensitive   {@code true} then a case insensitive compare is run to compare values.
      * otherwise a case sensitive compare is run to compare values.
+     * @return                  {@code true} if its contained, {@code false} otherwise.
      */
     boolean contains(CharSequence name, CharSequence value, boolean caseInsensitive);
 }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3HeadersFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3HeadersFrame.java
@@ -16,11 +16,13 @@
 package io.netty.incubator.codec.http3;
 
 /**
- * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.2>HEADERS</a>.
+ * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.2">HEADERS</a>.
  */
 public interface Http3HeadersFrame extends Http3RequestStreamFrame, Http3PushStreamFrame {
     /**
      * Returns the carried headers.
+     *
+     * @return the carried headers.
      */
     Http3Headers headers();
 }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3HeadersValidationException.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3HeadersValidationException.java
@@ -19,10 +19,22 @@ package io.netty.incubator.codec.http3;
  * Thrown if {@link Http3Headers} validation fails for some reason.
  */
 public final class Http3HeadersValidationException extends RuntimeException {
+
+    /**
+     * Create a new instance.
+     *
+     * @param message   the message.
+     */
     public Http3HeadersValidationException(String message) {
         super(message);
     }
 
+    /**
+     * Create a new instance.
+     *
+     * @param message   the message.
+     * @param cause     the wrapped {@link Throwable}.
+     */
     public Http3HeadersValidationException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3MaxPushIdFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3MaxPushIdFrame.java
@@ -16,12 +16,14 @@
 package io.netty.incubator.codec.http3;
 
 /**
- * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.7>MAX_PUSH_ID</a>.
+ * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.7">MAX_PUSH_ID</a>.
  */
 public interface Http3MaxPushIdFrame extends Http3ControlStreamFrame {
 
     /**
      * Returns the maximum value for a Push ID that the server can use.
+     *
+     * @return the id.
      */
     long id();
 }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3PushPromiseFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3PushPromiseFrame.java
@@ -16,16 +16,20 @@
 package io.netty.incubator.codec.http3;
 
 /**
- * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.5>PUSH_PROMISE</a>.
+ * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.5">PUSH_PROMISE</a>.
  */
 public interface Http3PushPromiseFrame extends Http3RequestStreamFrame {
     /**
      * Returns the push id.
+     *
+     * @return the id.
      */
     long id();
 
     /**
      * Returns the carried headers.
+     *
+     * @return the headers.
      */
     Http3Headers headers();
 }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3SettingsFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3SettingsFrame.java
@@ -18,9 +18,23 @@ package io.netty.incubator.codec.http3;
 import java.util.Map;
 
 /**
- * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.4>SETTINGS</a>.
+ * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.4">SETTINGS</a>.
  */
 public interface Http3SettingsFrame extends Http3ControlStreamFrame, Iterable<Map.Entry<Long, Long>> {
+    /**
+     * Get a setting from the frame.
+     *
+     * @param key   the key of the setting.
+     * @return      the value of the setting or {@code null} if none was found with the given key.
+     */
     Long get(long key);
-    void put(long key, Long value);
+
+    /**
+     * Put a setting in the frame.
+     *
+     * @param key       the key of the setting
+     * @param value     the value of the setting.
+     * @return          the previous stored valued for the given key or {@code null} if none was stored before.
+     */
+    Long put(long key, Long value);
 }


### PR DESCRIPTION
Motivation:

Our javadocs should not produce any errors when generating these.

Modifications:

Fix javadocs

Result:

No more errors when generating javadocs