### PR TITLE
Update to the latest quic codec release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <skipTests>false</skipTests>
     <netty.version>4.1.55.Final</netty.version>
     <netty.build.version>28</netty.build.version>
-    <netty.quic.version>0.0.1.Final-SNAPSHOT</netty.quic.version>
+    <netty.quic.version>0.0.1.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
   </properties>
 

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ServerExample.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ServerExample.java
@@ -30,6 +30,7 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 
 import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
 
 public final class Http3ServerExample {
     private static final byte[] CONTENT = "Hello World!\r\n".getBytes(CharsetUtil.US_ASCII);
@@ -40,14 +41,11 @@ public final class Http3ServerExample {
         ChannelHandler codec = Http3.newQuicServerCodecBuilder()
                 .certificateChain("./src/test/resources/cert.crt")
                 .privateKey("./src/test/resources/cert.key")
-                .maxIdleTimeout(5000)
-                .maxUdpPayloadSize(1350)
+                .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
                 .initialMaxData(10000000)
                 .initialMaxStreamDataBidirectionalLocal(1000000)
                 .initialMaxStreamDataBidirectionalRemote(1000000)
                 .initialMaxStreamsBidirectional(100)
-                .disableActiveMigration(true)
-                .enableEarlyData()
                 .tokenHandler(InsecureQuicTokenHandler.INSTANCE)
                 .handler(new ChannelInitializer<QuicChannel>() {
                     @Override


### PR DESCRIPTION
Motivation:

We finally have a release for the netty quic codec, so use it.

Modifications:

Use the release and adjust example for the API changes

Result:

No longer depend on a snapshot