### PR TITLE
Correctly encoder / decode and handle unknown HTTP/3 frames

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/DefaultHttp3UnknownFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/DefaultHttp3UnknownFrame.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.DefaultByteBufHolder;
+import io.netty.util.internal.StringUtil;
+
+import java.util.Objects;
+
+public final class DefaultHttp3UnknownFrame extends DefaultByteBufHolder implements Http3UnknownFrame {
+    private final long type;
+
+    public DefaultHttp3UnknownFrame(long type, ByteBuf payload) {
+        super(payload);
+        this.type = Http3CodecUtils.checkIsReservedFrameType(type);
+    }
+
+    @Override
+    public long type() {
+        return type;
+    }
+
+    @Override
+    public Http3UnknownFrame copy() {
+        return new DefaultHttp3UnknownFrame(type, content().copy());
+    }
+
+    @Override
+    public Http3UnknownFrame duplicate() {
+        return new DefaultHttp3UnknownFrame(type, content().duplicate());
+    }
+
+    @Override
+    public Http3UnknownFrame retainedDuplicate() {
+        return new DefaultHttp3UnknownFrame(type, content().retainedDuplicate());
+    }
+
+    @Override
+    public Http3UnknownFrame replace(ByteBuf content) {
+        return new DefaultHttp3UnknownFrame(type, content);
+    }
+
+    @Override
+    public Http3UnknownFrame retain() {
+        super.retain();
+        return this;
+    }
+
+    @Override
+    public Http3UnknownFrame retain(int increment) {
+        super.retain(increment);
+        return this;
+    }
+
+    @Override
+    public Http3UnknownFrame touch() {
+        super.touch();
+        return this;
+    }
+
+    @Override
+    public Http3UnknownFrame touch(Object hint) {
+        super.touch(hint);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return StringUtil.simpleClassName(this) + "(type=" + type() + ", content=" + content() + ')';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultHttp3UnknownFrame that = (DefaultHttp3UnknownFrame) o;
+        if (type != that.type) {
+            return false;
+        }
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), type);
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamFrameDispatcher.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamFrameDispatcher.java
@@ -45,7 +45,9 @@ final class Http3ControlStreamFrameDispatcher extends ChannelOutboundHandlerAdap
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         // Check if we are already on the local control frame or not.
-        if (ctx.channel() != localControlStream && msg instanceof Http3ControlStreamFrame) {
+        if (ctx.channel() != localControlStream && msg instanceof Http3ControlStreamFrame &&
+                // We can not make any smart decision for unknown frames as there are allowed on all stream types.
+                !(msg instanceof Http3UnknownFrame)) {
             // write and flush as otherwise we may never flush the control stream for the write.
             localControlStream.writeAndFlush(msg).addListener(new ChannelPromiseNotifier(promise));
             return;

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamInboundHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamInboundHandler.java
@@ -85,10 +85,10 @@ final class Http3ControlStreamInboundHandler extends Http3FrameTypeValidationHan
             }
         } else if (frame instanceof Http3CancelPushFrame) {
             // TODO: implement me
-        } else {
-            // TODO: Do we need to do something to handle unknown frames
         }
 
+        // We don't need to do any special handling for Http3UnknownFrames as we either pass these to the next handler
+        // or release these directly.
         if (forwardControlFrames) {
             // The user did specify ChannelHandler that should be notified about control stream frames.
             // Let's forward the frame so the user can do something with it.

--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandler.java
@@ -34,9 +34,13 @@ class Http3FrameTypeValidationHandler<T extends Http3Frame> extends ChannelDuple
         return (T) msg;
     }
 
+    private boolean isValid(Object msg) {
+        return frameType.isInstance(msg);
+    }
+
     @Override
     public final void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-        if (frameType.isInstance(msg)) {
+        if (isValid(msg)) {
             write(ctx, cast(msg), promise);
         } else {
             frameTypeUnexpected(promise, msg);
@@ -49,7 +53,7 @@ class Http3FrameTypeValidationHandler<T extends Http3Frame> extends ChannelDuple
 
     @Override
     public final void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        if (frameType.isInstance(msg)) {
+        if (isValid(msg)) {
             channelRead(ctx, cast(msg));
         } else {
             frameTypeUnexpected(ctx, msg);

--- a/src/main/java/io/netty/incubator/codec/http3/Http3RequestStreamInboundHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3RequestStreamInboundHandler.java
@@ -42,31 +42,70 @@ public abstract class Http3RequestStreamInboundHandler extends ChannelInboundHan
     public final void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         firstFrameReceived = true;
         boolean inputShutdown = ((QuicStreamChannel) ctx.channel()).isInputShutdown();
-        if (inputShutdown) {
-            lastFrameDetected = true;
+        if (msg instanceof Http3UnknownFrame) {
+            channelRead(ctx, (Http3UnknownFrame) msg);
+            if (inputShutdown) {
+                notifyLast(ctx);
+            }
+        } else {
+            if (inputShutdown) {
+                lastFrameDetected = true;
+            }
+            if (msg instanceof Http3HeadersFrame) {
+                channelRead(ctx, (Http3HeadersFrame) msg, inputShutdown);
+            }
+            if (msg instanceof Http3DataFrame) {
+                channelRead(ctx, (Http3DataFrame) msg, inputShutdown);
+            }
         }
-        channelRead(ctx, (Http3RequestStreamFrame) msg, inputShutdown);
     }
 
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt == ChannelInputShutdownEvent.INSTANCE) {
-            if (!lastFrameDetected && firstFrameReceived) {
-                lastFrameDetected = true;
-                channelRead(ctx, EMPTY, true);
-            }
+            notifyLast(ctx);
         }
         ctx.fireUserEventTriggered(evt);
     }
 
+    private void notifyLast(ChannelHandlerContext ctx) throws Exception {
+        if (!lastFrameDetected && firstFrameReceived) {
+            lastFrameDetected = true;
+            channelRead(ctx, EMPTY, true);
+        }
+    }
+
     /**
-     * Called once a {@link Http3RequestStreamFrame} is ready for this stream to process.
+     * Called once a {@link Http3HeadersFrame} is ready for this stream to process.
      *
      * @param ctx           the {@link ChannelHandlerContext} of this handler.
-     * @param frame         the {@link Http3RequestStreamFrame} that was read
+     * @param frame         the {@link Http3HeadersFrame} that was read
      * @param isLast        {@code true} if this is the last frame that will be read for this stream.
      * @throws Exception    thrown if an error happens during processing.
      */
-    public abstract void channelRead(ChannelHandlerContext ctx, Http3RequestStreamFrame frame, boolean isLast)
+    protected abstract void channelRead(ChannelHandlerContext ctx, Http3HeadersFrame frame, boolean isLast)
             throws Exception;
+
+    /**
+     * Called once a {@link Http3DataFrame} is ready for this stream to process.
+     *
+     * @param ctx           the {@link ChannelHandlerContext} of this handler.
+     * @param frame         the {@link Http3DataFrame} that was read
+     * @param isLast        {@code true} if this is the last frame that will be read for this stream.
+     * @throws Exception    thrown if an error happens during processing.
+     */
+    protected abstract void channelRead(ChannelHandlerContext ctx, Http3DataFrame frame, boolean isLast)
+            throws Exception;
+
+    /**
+     * Called once a {@link Http3UnknownFrame} is ready for this stream to process. By default these frames are just
+     * released and so dropped on the floor as stated in the RFC. That said you may want to override this method if
+     * you use some custom frames which are not part of the main spec.
+     *
+     * @param ctx           the {@link ChannelHandlerContext} of this handler.
+     * @param frame         the {@link Http3UnknownFrame} that was read
+     */
+    protected void channelRead(@SuppressWarnings("unused") ChannelHandlerContext ctx, Http3UnknownFrame frame) {
+        frame.release();
+    }
 }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3UnknownFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3UnknownFrame.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+
+/**
+ * <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.8">Unknown HTTP3 frame</a>.
+ * These frames are valid on all stream types.
+ * <pre>
+ *    HTTP/3 Frame Format {
+ *      Type (i),
+ *      Length (i),
+ *      Frame Payload (..),
+ *    }
+ * </pre>
+ */
+public interface Http3UnknownFrame extends
+        Http3RequestStreamFrame, Http3PushStreamFrame, Http3ControlStreamFrame, ByteBufHolder {
+
+    /**
+     * Return the type of the frame.
+     *
+     * @return the type.
+     */
+
+    long type();
+
+    /**
+     * Return the payload length of the frame.
+     *
+     * @return the length.
+     */
+    default long length() {
+        return content().readableBytes();
+    }
+
+    @Override
+    Http3UnknownFrame copy();
+
+    @Override
+    Http3UnknownFrame duplicate();
+
+    @Override
+    Http3UnknownFrame retainedDuplicate();
+
+    @Override
+    Http3UnknownFrame replace(ByteBuf content);
+
+    @Override
+    Http3UnknownFrame retain();
+
+    @Override
+    Http3UnknownFrame retain(int increment);
+
+    @Override
+    Http3UnknownFrame touch();
+
+    @Override
+    Http3UnknownFrame touch(Object hint);
+}

--- a/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamInboundHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamInboundHandlerTest.java
@@ -65,8 +65,15 @@ public class Http3RequestStreamInboundHandlerTest {
     }
 
     private static final class TestHttp3RequestStreamInboundHandler extends Http3RequestStreamInboundHandler {
+
         @Override
-        public void channelRead(ChannelHandlerContext ctx, Http3RequestStreamFrame frame, boolean isLast) {
+        public void channelRead(ChannelHandlerContext ctx, Http3HeadersFrame frame, boolean isLast) {
+            ctx.fireChannelRead(frame);
+            ctx.fireChannelRead(isLast);
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Http3DataFrame frame, boolean isLast) {
             ctx.fireChannelRead(frame);
             ctx.fireChannelRead(isLast);
         }

--- a/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamValidationHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamValidationHandlerTest.java
@@ -42,7 +42,8 @@ public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValid
 
     @Override
     protected List<Http3RequestStreamFrame> newValidFrames() {
-        return Arrays.asList(new DefaultHttp3HeadersFrame(), new DefaultHttp3DataFrame(Unpooled.directBuffer()));
+        return Arrays.asList(new DefaultHttp3HeadersFrame(), new DefaultHttp3DataFrame(Unpooled.directBuffer()),
+                new DefaultHttp3UnknownFrame(Http3CodecUtils.MAX_RESERVED_FRAME_TYPE, Unpooled.buffer()));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

We need handle unknown HTTP/3 frames correctly to not fail if a peer is using an extension we not support (yet).

Modifications:

- Add Http3UnknownFrame and DefaultHttp3UnknownFrame
- Refactor HttpRequestStreamInboundHandler to be useful with Http3UnknownFrame
- Adjust encoder and decoder to handle the unknown frames and also do some validation as stated by the spec
- Add unit tests for unknown frame handling

Result:

Correctly handle unknown frames on all stream types