### PR TITLE
We need to handle correctly unkown stream types.

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3UnidirectionalStreamInboundHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3UnidirectionalStreamInboundHandler.java
@@ -57,7 +57,7 @@ final class Http3UnidirectionalStreamInboundHandler extends ByteToMessageDecoder
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
         if (!in.isReadable()) {
             return;
         }
@@ -171,12 +171,13 @@ final class Http3UnidirectionalStreamInboundHandler extends ByteToMessageDecoder
     }
 
     /**
-     * Called if we couldn't detect the stream type of the current {@link Channel}.
+     * Called if we couldn't detect the stream type of the current {@link Channel}. Let's release everything that
+     * we receive on this stream.
      */
-    protected void initUnknownStream(ChannelHandlerContext ctx,
+    private void initUnknownStream(ChannelHandlerContext ctx,
                                      @SuppressWarnings("unused") long streamType,
-                                     @SuppressWarnings("unused") ByteBuf in) throws Exception {
-        ctx.close();
+                                     @SuppressWarnings("unused") ByteBuf in) {
+        ctx.pipeline().replace(this, null, ReleaseHandler.INSTANCE);
     }
 
     private static final class ReleaseHandler extends ChannelInboundHandlerAdapter {

--- a/src/test/java/io/netty/incubator/codec/http3/Http3UnidirectionalStreamInboundHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3UnidirectionalStreamInboundHandlerTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -62,7 +63,12 @@ public class Http3UnidirectionalStreamInboundHandlerTest {
         assertFalse(channel.writeInbound(buffer));
         assertEquals(0, buffer.refCnt());
         assertNull(channel.pipeline().context(Http3UnidirectionalStreamInboundHandler.class));
-        assertFalse(channel.isActive());
+        assertTrue(channel.isActive());
+
+        // Write some buffer to the stream. This should be just released.
+        ByteBuf someBuffer = Unpooled.buffer();
+        assertFalse(channel.writeInbound(someBuffer));
+        assertEquals(0, someBuffer.refCnt());
         assertFalse(channel.finish());
     }
 


### PR DESCRIPTION
Motivation:

If we receive an unkown stream type we should just drop all bytes on the floor as stated in the RFC.

Modifications:

- Correctly replace Http3UnidirectionalStreamInboundHandler with a handler that drops bytes on the floor.
- Adjust test

Result:

Correctly handle unkown stream types