### PR TITLE
Allow to specify a custom unknown stream handler

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.util.internal.ObjectUtil;
 
+import java.util.function.LongFunction;
 import java.util.function.Supplier;
 
 
@@ -36,24 +37,28 @@ public final class Http3ServerConnectionHandler extends Http3ConnectionHandler {
      *                              This handler will receive {@link Http3HeadersFrame} and {@link Http3DataFrame}s.
      */
     public Http3ServerConnectionHandler(ChannelHandler requestStreamHandler) {
-        this(requestStreamHandler, null, null);
+        this(requestStreamHandler, null, null, null);
     }
 
     /**
      * Create a new instance.
-     * @param requestStreamHandler          the {@link ChannelHandler} that is used for each new request stream.
-     *                                      This handler will receive {@link Http3HeadersFrame} and
-     *                                      {@link Http3DataFrame}s.
-     * @param inboundControlStreamHandler   the {@link ChannelHandler} which will be notified about
-     *                                      {@link Http3RequestStreamFrame}s or {@code null} if the user is not
-     *                                      interested in these.
-     * @param localSettings                 the local {@link Http3SettingsFrame} that should be sent to the remote peer
-     *                                      or {@code null} if the default settings should be used.
+     * @param requestStreamHandler                  the {@link ChannelHandler} that is used for each new request stream.
+     *                                              This handler will receive {@link Http3HeadersFrame} and
+     *                                              {@link Http3DataFrame}s.
+     * @param inboundControlStreamHandler           the {@link ChannelHandler} which will be notified about
+     *                                              {@link Http3RequestStreamFrame}s or {@code null} if the user is not
+     *                                              interested in these.
+     * @param unknownInboundStreamHandlerFactory    the {@link LongFunction} that will provide a custom
+     *                                              {@link ChannelHandler} for unknown inbound stream types or
+     *                                              {@code null} if no special handling should be done.
+     * @param localSettings                         the local {@link Http3SettingsFrame} that should be sent to the
+     *                                             remote peer or {@code null} if the default settings should be used.
      */
     public Http3ServerConnectionHandler(ChannelHandler requestStreamHandler,
                                         ChannelHandler inboundControlStreamHandler,
+                                        LongFunction<ChannelHandler> unknownInboundStreamHandlerFactory,
                                         Http3SettingsFrame localSettings) {
-        super(true, inboundControlStreamHandler, localSettings);
+        super(true, inboundControlStreamHandler, unknownInboundStreamHandlerFactory, localSettings);
         this.requestStreamHandler = ObjectUtil.checkNotNull(requestStreamHandler, "requestStreamHandler");
     }
 

--- a/src/test/java/io/netty/incubator/codec/http3/Http3TestUtils.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3TestUtils.java
@@ -70,6 +70,15 @@ final class Http3TestUtils {
         }
     }
 
+    static void assertBufferEquals(ByteBuf expected, ByteBuf actual) {
+        try {
+            assertEquals(expected, actual);
+        } finally {
+            ReferenceCountUtil.release(expected);
+            ReferenceCountUtil.release(actual);
+        }
+    }
+
     static void assertFrameEquals(Http3Frame expected, Http3Frame actual) {
         try {
             assertEquals(expected, actual);


### PR DESCRIPTION
Motivation:

To be able to implement extensions in the future the user should be able to adjust how unknown stream types are handles.

Modifications:

- Allow to specify a LongFunction that will be called for unknown stream types.
- Add tests

Result:

Be able to customize handling of unknown stream types