### PR TITLE
Add Http3Frame.type() method

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3CancelPushFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3CancelPushFrame.java
@@ -20,6 +20,11 @@ package io.netty.incubator.codec.http3;
  */
 public interface Http3CancelPushFrame extends Http3ControlStreamFrame {
 
+    @Override
+    default long type() {
+        return Http3CodecUtils.HTTP3_CANCEL_PUSH_FRAME_TYPE;
+    }
+
     /**
      * Returns the push id that identifies the server push that is being cancelled.
      *

--- a/src/main/java/io/netty/incubator/codec/http3/Http3DataFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3DataFrame.java
@@ -24,6 +24,11 @@ import io.netty.buffer.ByteBufHolder;
 public interface Http3DataFrame extends ByteBufHolder, Http3RequestStreamFrame, Http3PushStreamFrame {
 
     @Override
+    default long type() {
+        return Http3CodecUtils.HTTP3_DATA_FRAME_TYPE;
+    }
+
+    @Override
     Http3DataFrame copy();
 
     @Override

--- a/src/main/java/io/netty/incubator/codec/http3/Http3Frame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3Frame.java
@@ -18,4 +18,11 @@ package io.netty.incubator.codec.http3;
 /**
  * Marker interface that is implemented by all HTTP3 frames.
  */
-public interface Http3Frame { }
+public interface Http3Frame {
+    /**
+     * The type of the frame.
+     *
+     * @return the type.
+     */
+    long type();
+}

--- a/src/main/java/io/netty/incubator/codec/http3/Http3GoAwayFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3GoAwayFrame.java
@@ -20,6 +20,11 @@ package io.netty.incubator.codec.http3;
  */
 public interface Http3GoAwayFrame extends Http3ControlStreamFrame {
 
+    @Override
+    default long type() {
+        return Http3CodecUtils.HTTP3_GO_AWAY_FRAME_TYPE;
+    }
+
     /**
      * Returns the id.
      *

--- a/src/main/java/io/netty/incubator/codec/http3/Http3HeadersFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3HeadersFrame.java
@@ -19,6 +19,12 @@ package io.netty.incubator.codec.http3;
  * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.2">HEADERS</a>.
  */
 public interface Http3HeadersFrame extends Http3RequestStreamFrame, Http3PushStreamFrame {
+
+    @Override
+    default long type() {
+        return Http3CodecUtils.HTTP3_HEADERS_FRAME_TYPE;
+    }
+
     /**
      * Returns the carried headers.
      *

--- a/src/main/java/io/netty/incubator/codec/http3/Http3MaxPushIdFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3MaxPushIdFrame.java
@@ -20,6 +20,11 @@ package io.netty.incubator.codec.http3;
  */
 public interface Http3MaxPushIdFrame extends Http3ControlStreamFrame {
 
+    @Override
+    default long type() {
+        return Http3CodecUtils.HTTP3_MAX_PUSH_ID_FRAME_TYPE;
+    }
+
     /**
      * Returns the maximum value for a Push ID that the server can use.
      *

--- a/src/main/java/io/netty/incubator/codec/http3/Http3PushPromiseFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3PushPromiseFrame.java
@@ -19,6 +19,12 @@ package io.netty.incubator.codec.http3;
  * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.5">PUSH_PROMISE</a>.
  */
 public interface Http3PushPromiseFrame extends Http3RequestStreamFrame {
+
+    @Override
+    default long type() {
+        return Http3CodecUtils.HTTP3_PUSH_PROMISE_FRAME_TYPE;
+    }
+
     /**
      * Returns the push id.
      *

--- a/src/main/java/io/netty/incubator/codec/http3/Http3SettingsFrame.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3SettingsFrame.java
@@ -21,6 +21,12 @@ import java.util.Map;
  * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.4">SETTINGS</a>.
  */
 public interface Http3SettingsFrame extends Http3ControlStreamFrame, Iterable<Map.Entry<Long, Long>> {
+
+    @Override
+    default long type() {
+        return Http3CodecUtils.HTTP3_SETTINGS_FRAME_TYPE;
+    }
+
     /**
      * Get a setting from the frame.
      *

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamFrameDispatcherTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamFrameDispatcherTest.java
@@ -27,9 +27,9 @@ public class Http3ControlStreamFrameDispatcherTest {
     public void testOnlyDispatchControlFrame() {
         EmbeddedChannel controlChannel = new EmbeddedChannel();
         EmbeddedChannel channel = new EmbeddedChannel(new Http3ControlStreamFrameDispatcher(controlChannel));
-        Http3Frame frame = new Http3Frame() { };
-        Http3RequestStreamFrame requestStreamFrame = new Http3RequestStreamFrame() { };
-        Http3PushStreamFrame pushStreamFrame = new Http3PushStreamFrame() { };
+        Http3Frame frame = Http3TestUtils.newHttp3Frame();
+        Http3RequestStreamFrame requestStreamFrame = Http3TestUtils.newHttp3RequestStreamFrame();
+        Http3PushStreamFrame pushStreamFrame = Http3TestUtils.newHttp3PushStreamFrame();
 
         assertTrue(channel.writeOutbound(frame));
         assertTrue(channel.writeOutbound(requestStreamFrame));
@@ -45,7 +45,7 @@ public class Http3ControlStreamFrameDispatcherTest {
     public void testDispatchControlFrame() {
         EmbeddedChannel controlChannel = new EmbeddedChannel();
         EmbeddedChannel channel = new EmbeddedChannel(new Http3ControlStreamFrameDispatcher(controlChannel));
-        Http3ControlStreamFrame frame = new Http3ControlStreamFrame() { };
+        Http3ControlStreamFrame frame = Http3TestUtils.newHttp3ControlStreamFrame();
 
         assertFalse(channel.writeOutbound(frame));
         assertFalse(channel.finish());

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamInboundHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamInboundHandlerTest.java
@@ -72,7 +72,7 @@ public class Http3ControlStreamInboundHandlerTest extends
 
     @Override
     protected List<Http3Frame> newInvalidFrames() {
-        return Arrays.asList(new Http3RequestStreamFrame() { }, new Http3PushStreamFrame() { });
+        return Arrays.asList(Http3TestUtils.newHttp3RequestStreamFrame(), Http3TestUtils.newHttp3PushStreamFrame());
     }
 
     @Test

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamOutboundHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamOutboundHandlerTest.java
@@ -50,7 +50,7 @@ public class Http3ControlStreamOutboundHandlerTest extends
 
     @Override
     protected List<Http3Frame> newInvalidFrames() {
-        return Arrays.asList(new Http3RequestStreamFrame() { }, new Http3PushStreamFrame() { });
+        return Arrays.asList(Http3TestUtils.newHttp3RequestStreamFrame(), Http3TestUtils.newHttp3PushStreamFrame());
     }
 
     @Test

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandlerTest.java
@@ -29,11 +29,11 @@ public class Http3FrameTypeValidationHandlerTest extends
 
     @Override
     protected List<Http3RequestStreamFrame> newValidFrames() {
-        return Collections.singletonList(new Http3RequestStreamFrame() { });
+        return Collections.singletonList(Http3TestUtils.newHttp3RequestStreamFrame());
     }
 
     @Override
     protected List<Http3Frame> newInvalidFrames() {
-        return Arrays.asList(new Http3ControlStreamFrame() { }, new Http3PushStreamFrame() { });
+        return Arrays.asList(Http3TestUtils.newHttp3ControlStreamFrame(), Http3TestUtils.newHttp3PushStreamFrame());
     }
 }

--- a/src/test/java/io/netty/incubator/codec/http3/Http3PushStreamValidationHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3PushStreamValidationHandlerTest.java
@@ -34,6 +34,6 @@ public class Http3PushStreamValidationHandlerTest extends
 
     @Override
     protected List<Http3Frame> newInvalidFrames() {
-        return Arrays.asList(new Http3RequestStreamFrame() { }, new Http3ControlStreamFrame() { });
+        return Arrays.asList(Http3TestUtils.newHttp3RequestStreamFrame(), Http3TestUtils.newHttp3ControlStreamFrame());
     }
 }

--- a/src/test/java/io/netty/incubator/codec/http3/Http3TestUtils.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3TestUtils.java
@@ -102,4 +102,20 @@ final class Http3TestUtils {
             assertEquals(0, ((ReferenceCounted) frame).refCnt());
         }
     }
+
+    static Http3Frame newHttp3Frame() {
+        return ()  -> 0;
+    }
+
+    static Http3PushStreamFrame newHttp3PushStreamFrame() {
+        return ()  -> 0;
+    }
+
+    static Http3RequestStreamFrame newHttp3RequestStreamFrame() {
+        return ()  -> 0;
+    }
+
+    static Http3ControlStreamFrame newHttp3ControlStreamFrame() {
+        return ()  -> 0;
+    }
 }


### PR DESCRIPTION
Motivation:

It's generally useful to have a type() method which returns what is specified in the RFC for the frame type.

Modifications:

- Add type() method and use it in the encoder
- Update tests

Result:

Have type() method