### PR TITLE
Add tests for Http3ConnectionHandler subclasses and fix some bugs

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3ClientConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ClientConnectionHandler.java
@@ -17,6 +17,7 @@ package io.netty.incubator.codec.http3;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.incubator.codec.quic.QuicStreamChannel;
 
 import java.util.function.LongFunction;
 import java.util.function.Supplier;
@@ -49,7 +50,8 @@ public final class Http3ClientConnectionHandler extends Http3ConnectionHandler {
     }
 
     @Override
-    void initBidirectionalStream(ChannelHandlerContext ctx, Supplier<Http3FrameCodec> codecSupplier) {
+    void initBidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel channel,
+                                 Supplier<Http3FrameCodec> codecSupplier) {
         // See https://tools.ietf.org/html/draft-ietf-quic-http-32#section-6.1
         Http3CodecUtils.connectionError(ctx, Http3ErrorCode.H3_STREAM_CREATION_ERROR,
                 "Server initiated bidirectional streams are not allowed", true);

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
@@ -18,6 +18,7 @@ package io.netty.incubator.codec.http3;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
+import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.util.internal.ObjectUtil;
 
 import java.util.function.LongFunction;
@@ -63,8 +64,9 @@ public final class Http3ServerConnectionHandler extends Http3ConnectionHandler {
     }
 
     @Override
-    void initBidirectionalStream(ChannelHandlerContext ctx, Supplier<Http3FrameCodec> codecSupplier) {
-        ChannelPipeline pipeline = ctx.pipeline();
+    void initBidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel streamChannel,
+                                 Supplier<Http3FrameCodec> codecSupplier) {
+        ChannelPipeline pipeline = streamChannel.pipeline();
         // Add the encoder and decoder in the pipeline so we can handle Http3Frames
         pipeline.addLast(codecSupplier.get());
         pipeline.addLast(new Http3RequestStreamValidationHandler(true));

--- a/src/test/java/io/netty/incubator/codec/http3/AbtractHttp3ConnectionHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/AbtractHttp3ConnectionHandlerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.DefaultChannelPipeline;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.incubator.codec.quic.QuicStreamChannel;
+import io.netty.incubator.codec.quic.QuicStreamType;
+import io.netty.util.AttributeMap;
+import io.netty.util.DefaultAttributeMap;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public abstract class AbtractHttp3ConnectionHandlerTest {
+
+    protected abstract Http3ConnectionHandler newConnectionHandler();
+
+    protected abstract void assertBidirectionalStreamHandled(QuicChannel channel, QuicStreamChannel streamChannel);
+
+    @Test
+    public void testOpenLocalControlStream() throws Exception {
+        QuicChannel quicChannel = mock(QuicChannel.class);
+        QuicStreamChannel localControlStreamChannel = mock(QuicStreamChannel.class);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+
+        AttributeMap attributeMap = new DefaultAttributeMap();
+        when(quicChannel.attr(any())).then(a -> attributeMap.attr(a.getArgument(0)));
+        when(quicChannel.createStream(any(QuicStreamType.class), any(ChannelHandler.class)))
+                .thenReturn(ImmediateEventExecutor.INSTANCE.newSucceededFuture(localControlStreamChannel));
+
+        when(ctx.channel()).thenReturn(quicChannel);
+        Http3ConnectionHandler handler = newConnectionHandler();
+        handler.handlerAdded(ctx);
+        handler.channelRegistered(ctx);
+        handler.channelActive(ctx);
+
+        assertEquals(localControlStreamChannel, Http3.getLocalControlStream(quicChannel));
+
+        handler.channelInactive(ctx);
+        handler.channelUnregistered(ctx);
+        handler.handlerRemoved(ctx);
+    }
+
+    @Test
+    public void testBidirectionalStream() throws Exception {
+        QuicChannel quicChannel = mock(QuicChannel.class);
+        QuicStreamChannel localControlStreamChannel = mock(QuicStreamChannel.class);
+        QuicStreamChannel bidirectionalStream = mock(QuicStreamChannel.class);
+
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+
+        AttributeMap attributeMap = new DefaultAttributeMap();
+        when(quicChannel.attr(any())).then(a -> attributeMap.attr(a.getArgument(0)));
+        when(quicChannel.createStream(any(QuicStreamType.class), any(ChannelHandler.class)))
+                .thenReturn(ImmediateEventExecutor.INSTANCE.newSucceededFuture(localControlStreamChannel));
+        when(quicChannel.close(anyBoolean(), anyInt(),
+                any(ByteBuf.class))).thenReturn(new DefaultChannelPromise(quicChannel));
+        when(quicChannel.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
+
+        when(ctx.channel()).thenReturn(quicChannel);
+
+        when(bidirectionalStream.type()).thenReturn(QuicStreamType.BIDIRECTIONAL);
+        when(bidirectionalStream.parent()).thenReturn(quicChannel);
+
+        ChannelPipeline pipeline = new DefaultChannelPipeline(bidirectionalStream) { };
+        when(bidirectionalStream.pipeline()).thenReturn(pipeline);
+
+        Http3ConnectionHandler handler = newConnectionHandler();
+        handler.handlerAdded(ctx);
+        handler.channelRegistered(ctx);
+        handler.channelActive(ctx);
+
+        handler.channelRead(ctx, bidirectionalStream);
+
+        assertBidirectionalStreamHandled(quicChannel, bidirectionalStream);
+        handler.channelInactive(ctx);
+        handler.channelUnregistered(ctx);
+        handler.handlerRemoved(ctx);
+    }
+
+    @Test
+    public void testUnidirectionalStream() throws Exception {
+        QuicChannel quicChannel = mock(QuicChannel.class);
+        QuicStreamChannel localControlStream = mock(QuicStreamChannel.class);
+        QuicStreamChannel unidirectionalStream = mock(QuicStreamChannel.class);
+
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+
+        AttributeMap attributeMap = new DefaultAttributeMap();
+        when(quicChannel.attr(any())).then(a -> attributeMap.attr(a.getArgument(0)));
+        when(quicChannel.createStream(any(QuicStreamType.class), any(ChannelHandler.class)))
+                .thenReturn(ImmediateEventExecutor.INSTANCE.newSucceededFuture(localControlStream));
+        when(quicChannel.close(anyBoolean(), anyInt(),
+                any(ByteBuf.class))).thenReturn(new DefaultChannelPromise(quicChannel));
+        when(quicChannel.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
+
+        when(ctx.channel()).thenReturn(quicChannel);
+
+        ChannelPipeline pipeline = new DefaultChannelPipeline(unidirectionalStream) { };
+        when(unidirectionalStream.pipeline()).thenReturn(pipeline);
+        when(unidirectionalStream.type()).thenReturn(QuicStreamType.UNIDIRECTIONAL);
+
+        Http3ConnectionHandler handler = newConnectionHandler();
+        handler.handlerAdded(ctx);
+        handler.channelRegistered(ctx);
+        handler.channelActive(ctx);
+
+        handler.channelRead(ctx, unidirectionalStream);
+
+        assertNotNull(pipeline.get(Http3UnidirectionalStreamInboundHandler.class));
+
+        handler.channelInactive(ctx);
+        handler.channelUnregistered(ctx);
+        handler.handlerRemoved(ctx);
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ClientConnectionHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ClientConnectionHandlerTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.incubator.codec.quic.QuicStreamChannel;
+
+public class Http3ClientConnectionHandlerTest extends AbtractHttp3ConnectionHandlerTest {
+
+    @Override
+    protected Http3ConnectionHandler newConnectionHandler() {
+        return new Http3ClientConnectionHandler();
+    }
+
+    @Override
+    protected void assertBidirectionalStreamHandled(QuicChannel channel, QuicStreamChannel streamChannel) {
+        Http3TestUtils.verifyClose(Http3ErrorCode.H3_STREAM_CREATION_ERROR, channel);
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandlerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.incubator.codec.quic.QuicStreamChannel;
+
+import static org.junit.Assert.assertNotNull;
+
+public class Http3ServerConnectionHandlerTest extends AbtractHttp3ConnectionHandlerTest {
+    private static final ChannelHandler REQUEST_HANDLER = new ChannelInboundHandlerAdapter() {
+        @Override
+        public boolean isSharable() {
+            return true;
+        }
+    };
+
+    @Override
+    protected Http3ConnectionHandler newConnectionHandler() {
+        return new Http3ServerConnectionHandler(REQUEST_HANDLER);
+    }
+
+    @Override
+    protected void assertBidirectionalStreamHandled(QuicChannel channel, QuicStreamChannel streamChannel) {
+        assertNotNull(streamChannel.pipeline().context(REQUEST_HANDLER));
+    }
+}


### PR DESCRIPTION
Motivation:

We didnt have tests for Http3ConnectionHandler subclasses which also resulted in some bugs related to how the pipelines were setup.

Modifications:

- Add tests
- Modify the correct pipelines
- Close the correct channel

Result:

More tests and fixed bugs