### PR TITLE
Fix possible infinite loop when the ByteBuf did contain more then one…

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameDecoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameDecoder.java
@@ -113,7 +113,7 @@ final class Http3FrameDecoder extends ByteToMessageDecoder {
                         // HEADERS
                         // https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.2
                         Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
-                        if (decodeHeaders(ctx, headersFrame.headers(), in)) {
+                        if (decodeHeaders(ctx, headersFrame.headers(), in.readSlice(payLoadLength))) {
                             out.add(headersFrame);
                         }
                         break;
@@ -139,7 +139,8 @@ final class Http3FrameDecoder extends ByteToMessageDecoder {
                         int pushPromiseIdLen = numBytesForVariableLengthInteger(in.getByte(in.readerIndex()));
                         Http3PushPromiseFrame pushPromiseFrame = new DefaultHttp3PushPromiseFrame(
                                 readVariableLengthInteger(in, pushPromiseIdLen));
-                        if (decodeHeaders(ctx, pushPromiseFrame.headers(), in)) {
+                        if (decodeHeaders(ctx, pushPromiseFrame.headers(),
+                                in.readSlice(payLoadLength - pushPromiseIdLen))) {
                             out.add(pushPromiseFrame);
                         }
                         break;

--- a/src/main/java/io/netty/incubator/codec/http3/QpackDecoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackDecoder.java
@@ -27,6 +27,9 @@ final class QpackDecoder {
     private static final QpackException NAME_ILLEGAL_INDEX_VALUE =
             QpackException.newStatic(QpackDecoder.class, "getIndexedName(...)", "QPACK - illegal index value");
 
+    private static final QpackException UNKNOWN_TYPE =
+            QpackException.newStatic(QpackDecoder.class, "decode(...)", "QPACK - unknown type");
+
     private final QpackHuffmanDecoder huffmanDecoder = new QpackHuffmanDecoder();
 
     /**
@@ -53,6 +56,8 @@ final class QpackDecoder {
             } else if ((b & 0xe0) == 0x20) {
                 // 001xxxxx
                 decodeLiteral(in, sink);
+            } else {
+                throw UNKNOWN_TYPE;
             }
         }
     }


### PR DESCRIPTION
… frame while decoding

Motivation:

We didn't correctly pass a slice to the QpackDecoder and so we could end up with an infinite loop when the buffer did contain more data after all headers were processed.

Modifications:

- Correctly slice the buffer in Http3FrameDecoder
- Throw in QpackDecoder if we encounter an unexpected value
- Add unit test for the change in QpackDecoder
- Add unit tests for the Http3FrameDecoder

Result:

No more infinite loop