### PR TITLE
Add support for HTTP/3 client side

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3.java
@@ -16,11 +16,18 @@
 package io.netty.incubator.codec.http3;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.incubator.codec.quic.QuicChannel;
 import io.netty.incubator.codec.quic.QuicClientCodecBuilder;
 import io.netty.incubator.codec.quic.QuicCodecBuilder;
 import io.netty.incubator.codec.quic.QuicServerCodecBuilder;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
+import io.netty.incubator.codec.quic.QuicStreamChannelBootstrap;
+import io.netty.incubator.codec.quic.QuicStreamType;
 import io.netty.util.AttributeKey;
+import io.netty.util.concurrent.Future;
+
+import java.util.function.Supplier;
 
 /**
  * Contains utility methods that help to bootstrap server / clients with HTTP3 support.
@@ -40,7 +47,7 @@ public final class Http3 {
             AttributeKey.valueOf(Http3.class, "HTTP3ControlStream");
 
     /**
-     * Return the local initiated control stream for the HTTP/3 connection.
+     * Returns the local initiated control stream for the HTTP/3 connection.
      * @param channel   the channel for the HTTP/3 connection.
      * @return          the control stream.
      */
@@ -50,6 +57,77 @@ public final class Http3 {
 
     static void setLocalControlStream(Channel channel, QuicStreamChannel controlStreamChannel) {
         channel.attr(HTTP3_CONTROL_STREAM_KEY).set(controlStreamChannel);
+    }
+
+    private static final AttributeKey<Supplier<? extends ChannelHandler>> HTTP3_CODEC_SUPPLIER =
+            AttributeKey.valueOf(Http3.class, "HTTP3CodecSupplier");
+
+    /**
+     * Returns the {@link Supplier} that should be used to obtain a HTTP/3 codec for the underlying connection.
+     *
+     * Usually you as an end-user you just want to use {@link Http3RequestStreamInitializer} directly.
+     *
+     * @param channel   the channel for the HTTP/3 connection.
+     * @return          the codec supplier.
+     */
+    public static Supplier<? extends ChannelHandler> getCodecSupplier(Channel channel) {
+        return channel.attr(HTTP3_CODEC_SUPPLIER).get();
+    }
+
+    static void setCodecSupplier(Channel channel, Supplier<? extends ChannelHandler> codecSupplier) {
+        channel.attr(HTTP3_CODEC_SUPPLIER).set(codecSupplier);
+    }
+
+    /**
+     * Returns a new HTTP/3 request-stream that will use the given {@link ChannelHandler}
+     * to dispatch {@link Http3RequestStreamFrame}s too. The needed HTTP/3 is automatically added to the
+     * pipeline as well.
+     *
+     * If you need more control you can also use the {@link Http3RequestStreamInitializer} directly.
+     *
+     * @param channel   the {@link QuicChannel} for which we create the request-stream.
+     * @param handler   the {@link ChannelHandler} to add.
+     * @return          the {@link Future} that will be notified once the request-stream was opened.
+     */
+    public static Future<QuicStreamChannel> newRequestStream(QuicChannel channel, ChannelHandler handler) {
+        final Http3RequestStreamInitializer initializer;
+        if (handler instanceof Http3RequestStreamInitializer) {
+            initializer = (Http3RequestStreamInitializer) handler;
+        } else {
+            initializer = new Http3RequestStreamInitializer() {
+                @Override
+                protected void initRequestStream(QuicStreamChannel ch) {
+                    ch.pipeline().addLast(handler);
+                }
+            };
+        }
+        return channel.createStream(QuicStreamType.BIDIRECTIONAL, initializer);
+    }
+
+    /**
+     * Returns a new HTTP/3 request-stream bootstrap that will use the given {@link ChannelHandler}
+     * to dispatch {@link Http3RequestStreamFrame}s too. The needed HTTP/3 is automatically added to the
+     * pipeline as well.
+     *
+     * If you need more control you can also use the {@link Http3RequestStreamInitializer} directly.
+     *
+     * @param channel   the {@link QuicChannel} for which we create the request-stream.
+     * @param handler   the {@link ChannelHandler} to add.
+     * @return          the {@link QuicStreamChannelBootstrap} that should be used.
+     */
+    public static QuicStreamChannelBootstrap newRequestStreamBootstrap(QuicChannel channel, ChannelHandler handler) {
+        final Http3RequestStreamInitializer initializer;
+        if (handler instanceof Http3RequestStreamInitializer) {
+            initializer = (Http3RequestStreamInitializer) handler;
+        } else {
+            initializer = new Http3RequestStreamInitializer() {
+                @Override
+                protected void initRequestStream(QuicStreamChannel ch) {
+                    ch.pipeline().addLast(handler);
+                }
+            };
+        }
+        return channel.newStreamBootstrap().handler(initializer).type(QuicStreamType.BIDIRECTIONAL);
     }
 
     /**

--- a/src/main/java/io/netty/incubator/codec/http3/Http3.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3.java
@@ -65,7 +65,7 @@ public final class Http3 {
     /**
      * Returns the {@link Supplier} that should be used to obtain a HTTP/3 codec for the underlying connection.
      *
-     * Usually you as an end-user you just want to use {@link Http3RequestStreamInitializer} directly.
+     * As an end-user in most cases you just want to use {@link Http3RequestStreamInitializer} directly.
      *
      * @param channel   the channel for the HTTP/3 connection.
      * @return          the codec supplier.

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ConnectionHandler.java
@@ -93,6 +93,7 @@ public abstract class Http3ConnectionHandler extends ChannelInboundHandlerAdapte
 
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) {
+        Http3.setCodecSupplier(ctx.channel(), codecSupplier);
         if (ctx.channel().isActive()) {
             createControlStreamIfNeeded(ctx);
         }

--- a/src/main/java/io/netty/incubator/codec/http3/Http3RequestStreamInitializer.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3RequestStreamInitializer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.incubator.codec.quic.QuicStreamChannel;
+
+import java.util.function.Supplier;
+
+/**
+ * Abstract base class that users can extend to init HTTP/3 request-streams. This initializer
+ * will automatically add HTTP/3 codecs etc to the {@link ChannelPipeline} as well.
+ */
+public abstract class Http3RequestStreamInitializer extends ChannelInitializer<QuicStreamChannel> {
+
+    @Override
+    protected final void initChannel(QuicStreamChannel ch) {
+        ChannelPipeline pipeline = ch.pipeline();
+        Supplier<? extends ChannelHandler> supplier = Http3.getCodecSupplier(ch.parent());
+        if (supplier == null) {
+            throw new IllegalStateException("Couldn't obtain the codec Supplier");
+        }
+        // Add the encoder and decoder in the pipeline so we can handle Http3Frames
+        pipeline.addLast(supplier.get());
+        // Add the handler that will validate what we write and receive on this stream.
+        //pipeline.addLast(new Http3RequestStreamValidationHandler(false));
+        initRequestStream(ch);
+    }
+
+    /**
+     * Init the {@link QuicStreamChannel} to handle {@link Http3RequestStreamFrame}s. At the point of calling this
+     * method it is already valid to write {@link Http3RequestStreamFrame}s as the codec is already in the pipeline.
+     * @param ch    the {QuicStreamChannel} for the request stream.
+     */
+    protected abstract void initRequestStream(QuicStreamChannel ch);
+}

--- a/src/test/java/io/netty/incubator/codec/http3/example/Http3ClientExample.java
+++ b/src/test/java/io/netty/incubator/codec/http3/example/Http3ClientExample.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3.example;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.incubator.codec.http3.DefaultHttp3HeadersFrame;
+import io.netty.incubator.codec.http3.Http3;
+import io.netty.incubator.codec.http3.Http3ClientConnectionHandler;
+import io.netty.incubator.codec.http3.Http3DataFrame;
+import io.netty.incubator.codec.http3.Http3HeadersFrame;
+import io.netty.incubator.codec.http3.Http3RequestStreamFrame;
+import io.netty.incubator.codec.http3.Http3RequestStreamInboundHandler;
+import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.incubator.codec.quic.QuicStreamChannel;
+import io.netty.util.CharsetUtil;
+import io.netty.util.NetUtil;
+import io.netty.util.ReferenceCountUtil;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+public final class Http3ClientExample {
+    private Http3ClientExample() { }
+
+    public static void main(String... args) throws Exception {
+        NioEventLoopGroup group = new NioEventLoopGroup(1);
+
+        try {
+            ChannelHandler codec = Http3.newQuicClientCodecBuilder()
+                    .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
+                    .initialMaxData(10000000)
+                    .initialMaxStreamDataBidirectionalLocal(1000000)
+                    .build();
+
+            Bootstrap bs = new Bootstrap();
+            Channel channel = bs.group(group)
+                    .channel(NioDatagramChannel.class)
+                    .handler(codec)
+                    .bind(0).sync().channel();
+
+            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+                    .handler(new Http3ClientConnectionHandler())
+                    .remoteAddress(new InetSocketAddress(NetUtil.LOCALHOST4, 9999))
+                    .connect()
+                    .get();
+
+            QuicStreamChannel streamChannel = Http3.newRequestStream(quicChannel,
+                    new Http3RequestStreamInboundHandler() {
+                        @Override
+                        protected void channelRead(ChannelHandlerContext ctx,
+                                                   Http3HeadersFrame frame, boolean isLast) {
+                            releaseFrameAndCloseIfLast(ctx, frame, isLast);
+                        }
+
+                        @Override
+                        protected void channelRead(ChannelHandlerContext ctx,
+                                                   Http3DataFrame frame, boolean isLast) {
+                            System.err.print(frame.content().toString(CharsetUtil.US_ASCII));
+                            releaseFrameAndCloseIfLast(ctx, frame, isLast);
+                        }
+
+                        private void releaseFrameAndCloseIfLast(ChannelHandlerContext ctx,
+                                                                Http3RequestStreamFrame frame, boolean isLast) {
+                            ReferenceCountUtil.release(frame);
+                            if (isLast) {
+                                ctx.close();
+                            }
+                        }
+                    }).sync().getNow();
+
+            // Write the Header frame and send the FIN to mark the end of the request.
+            // After this its not possible anymore to write any more data.
+            Http3HeadersFrame frame = new DefaultHttp3HeadersFrame();
+            frame.headers().method("GET").path("/");
+            streamChannel.writeAndFlush(frame)
+                    .addListener(QuicStreamChannel.SHUTDOWN_OUTPUT).sync();
+
+            // Wait for the stream channel and quic channel to be closed (this will happen after we received the FIN).
+            // After this is done we will close the underlying datagram channel.
+            streamChannel.closeFuture().sync();
+
+            // After we received the response lets also close the underlying QUIC channel and datagram channel.
+            quicChannel.close().sync();
+            channel.close().sync();
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/example/Http3ServerExample.java
+++ b/src/test/java/io/netty/incubator/codec/http3/example/Http3ServerExample.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.incubator.codec.http3;
+package io.netty.incubator.codec.http3.example;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.Unpooled;
@@ -23,6 +23,13 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.incubator.codec.http3.DefaultHttp3DataFrame;
+import io.netty.incubator.codec.http3.DefaultHttp3HeadersFrame;
+import io.netty.incubator.codec.http3.Http3;
+import io.netty.incubator.codec.http3.Http3DataFrame;
+import io.netty.incubator.codec.http3.Http3HeadersFrame;
+import io.netty.incubator.codec.http3.Http3RequestStreamInboundHandler;
+import io.netty.incubator.codec.http3.Http3ServerConnectionHandler;
 import io.netty.incubator.codec.quic.InsecureQuicTokenHandler;
 import io.netty.incubator.codec.quic.QuicChannel;
 import io.netty.incubator.codec.quic.QuicStreamChannel;


### PR DESCRIPTION
Motivation:

We should also support clients

Modifications:

- Add some utilities to make it easier to use HTTP/3 for clients.
- Add a client example

Result:

Support HTTP/3 for clients