### PR TITLE
Correctly fail new request on the client side if we received the goaway.

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3.java
@@ -59,25 +59,6 @@ public final class Http3 {
         channel.attr(HTTP3_CONTROL_STREAM_KEY).set(controlStreamChannel);
     }
 
-    private static final AttributeKey<Supplier<? extends ChannelHandler>> HTTP3_CODEC_SUPPLIER =
-            AttributeKey.valueOf(Http3.class, "HTTP3CodecSupplier");
-
-    /**
-     * Returns the {@link Supplier} that should be used to obtain a HTTP/3 codec for the underlying connection.
-     *
-     * As an end-user in most cases you just want to use {@link Http3RequestStreamInitializer} directly.
-     *
-     * @param channel   the channel for the HTTP/3 connection.
-     * @return          the codec supplier.
-     */
-    public static Supplier<? extends ChannelHandler> getCodecSupplier(Channel channel) {
-        return channel.attr(HTTP3_CODEC_SUPPLIER).get();
-    }
-
-    static void setCodecSupplier(Channel channel, Supplier<? extends ChannelHandler> codecSupplier) {
-        channel.attr(HTTP3_CODEC_SUPPLIER).set(codecSupplier);
-    }
-
     /**
      * Returns a new HTTP/3 request-stream that will use the given {@link ChannelHandler}
      * to dispatch {@link Http3RequestStreamFrame}s too. The needed HTTP/3 is automatically added to the

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ClientConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ClientConnectionHandler.java
@@ -20,7 +20,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 
 import java.util.function.LongFunction;
-import java.util.function.Supplier;
 
 public final class Http3ClientConnectionHandler extends Http3ConnectionHandler {
 
@@ -50,8 +49,7 @@ public final class Http3ClientConnectionHandler extends Http3ConnectionHandler {
     }
 
     @Override
-    void initBidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel channel,
-                                 Supplier<Http3FrameCodec> codecSupplier) {
+    void initBidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel channel) {
         // See https://tools.ietf.org/html/draft-ietf-quic-http-32#section-6.1
         Http3CodecUtils.connectionError(ctx, Http3ErrorCode.H3_STREAM_CREATION_ERROR,
                 "Server initiated bidirectional streams are not allowed", true);

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
@@ -22,7 +22,6 @@ import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.util.internal.ObjectUtil;
 
 import java.util.function.LongFunction;
-import java.util.function.Supplier;
 
 
 /**
@@ -64,12 +63,11 @@ public final class Http3ServerConnectionHandler extends Http3ConnectionHandler {
     }
 
     @Override
-    void initBidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel streamChannel,
-                                 Supplier<Http3FrameCodec> codecSupplier) {
+    void initBidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel streamChannel) {
         ChannelPipeline pipeline = streamChannel.pipeline();
         // Add the encoder and decoder in the pipeline so we can handle Http3Frames
-        pipeline.addLast(codecSupplier.get());
-        pipeline.addLast(new Http3RequestStreamValidationHandler(true));
+        pipeline.addLast(newCodec());
+        pipeline.addLast(Http3RequestStreamValidationHandler.newServerValidator());
         pipeline.addLast(requestStreamHandler);
     }
 }


### PR DESCRIPTION
Motivation:

We need to fail a new request when we did receive a goaway on the client side

Modifications:

- Correctly fail if we received a goaway
- Ensure we do type validation on the client side
- Add unit tests

Result:

Correctly handle goaway on the client side