### PR TITLE
Let's do some validation for outbound GOAWAY frames

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3ConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ConnectionHandler.java
@@ -66,7 +66,7 @@ public abstract class Http3ConnectionHandler extends ChannelInboundHandlerAdapte
         localSettings.put(Http3SettingsFrame.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0L);
         codecSupplier = Http3FrameCodec.newSupplier(new QpackDecoder(), maxFieldSectionSize, new QpackEncoder());
         localControlStreamHandler = new Http3ControlStreamInboundHandler(server, inboundControlStreamHandler);
-        remoteControlStreamHandler =  new Http3ControlStreamOutboundHandler(localSettings, codecSupplier.get());
+        remoteControlStreamHandler =  new Http3ControlStreamOutboundHandler(server, localSettings, codecSupplier.get());
     }
 
     private void createControlStreamIfNeeded(ChannelHandlerContext ctx) {

--- a/src/test/java/io/netty/incubator/codec/http3/Http3UnidirectionalStreamInboundHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3UnidirectionalStreamInboundHandlerTest.java
@@ -133,7 +133,7 @@ public class Http3UnidirectionalStreamInboundHandlerTest {
         AttributeMap map = new DefaultAttributeMap();
         when(parent.attr(any())).then(i -> map.attr(i.getArgument(0)));
 
-        Http3ControlStreamOutboundHandler outboundControlHandler = new Http3ControlStreamOutboundHandler(
+        Http3ControlStreamOutboundHandler outboundControlHandler = new Http3ControlStreamOutboundHandler(server,
                 new DefaultHttp3SettingsFrame(), new CodecHandler());
 
         EmbeddedChannel outboundControlChannel = new EmbeddedChannel(
@@ -210,7 +210,8 @@ public class Http3UnidirectionalStreamInboundHandlerTest {
         channel = new EmbeddedChannel(channel.parent(), DefaultChannelId.newInstance(),
                 true, false, new Http3UnidirectionalStreamInboundHandler(
                 CodecHandler::new, new Http3ControlStreamInboundHandler(server, null),
-                new Http3ControlStreamOutboundHandler(new DefaultHttp3SettingsFrame(), new CodecHandler()), null));
+                new Http3ControlStreamOutboundHandler(server, new DefaultHttp3SettingsFrame(),
+                        new CodecHandler()), null));
 
         // Try to create the stream a second time, this should fail
         buffer = Unpooled.buffer(8);
@@ -231,7 +232,8 @@ public class Http3UnidirectionalStreamInboundHandlerTest {
         when(parent.attr(any())).then(i -> map.attr(i.getArgument(0)));
         Http3UnidirectionalStreamInboundHandler handler = new Http3UnidirectionalStreamInboundHandler(
                 CodecHandler::new, new Http3ControlStreamInboundHandler(true, null),
-                new Http3ControlStreamOutboundHandler(new DefaultHttp3SettingsFrame(), new CodecHandler()), factory);
+                new Http3ControlStreamOutboundHandler(server, new DefaultHttp3SettingsFrame(),
+                        new CodecHandler()), factory);
         return new EmbeddedChannel(parent, DefaultChannelId.newInstance(),
                 true, false, handler);
     }


### PR DESCRIPTION
Motivation:

We should ensure the user doesnt try to send invalid GOAWAY frames

Modifications:

- Do some validation for server side.
- Add unit tests

Result:

Better validation