### PR TITLE
Update to latest quic codec release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <skipTests>false</skipTests>
     <netty.version>4.1.56.Final</netty.version>
     <netty.build.version>28</netty.build.version>
-    <netty.quic.version>0.0.1.Final</netty.quic.version>
+    <netty.quic.version>0.0.2.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
   </properties>
 


### PR DESCRIPTION
Motivation:

We should use latest quic codec version

Modifications:

Update to 0.0.2.Final

Result:

Use latest quic codec