### PR TITLE
Always use the mvn installation of the image

### DIFF
--- a/docker/Dockerfile.centos8
+++ b/docker/Dockerfile.centos8
@@ -24,6 +24,7 @@ RUN echo 'PATH=/jdk/bin:$PATH' >> ~/.bashrc
 
 WORKDIR /opt
 RUN curl https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar -xz
+RUN echo 'PATH=/opt/apache-maven-3.6.3/bin/:$PATH' >> ~/.bashrc
 
 # Prepare our own build
 ENV PATH /opt/apache-maven-3.6.3/bin/:$PATH

--- a/docker/docker-compose.centos-8.yaml
+++ b/docker/docker-compose.centos-8.yaml
@@ -19,7 +19,7 @@ services:
 
   build:
     <<: *common
-    command: /bin/bash -cl "./mvnw clean package"
+    command: /bin/bash -cl "mvn clean package"
 
   shell:
     <<: *common


### PR DESCRIPTION
Motivation:

Let's use always the mvn installation which is part of the image to minimize things that needs to be fetched

Modifications:

Use mvn directly

Result:

Less downloads during build