### PR TITLE
Only collect surefire reports

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,5 +40,5 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
-          name: target
-          path: target/ # or path/to/artifact
+          name: build-surefire-reports
+          path: "**/target/surefire-reports"

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -38,9 +38,3 @@ jobs:
 
       - name: Deploy project snapshot to sonatype
         run: docker-compose -f docker/docker-compose.centos-8.yaml -f docker/docker-compose.centos-8.18.yaml run deploy
-
-      - uses: actions/upload-artifact@v2
-        if: ${{ failure() }}
-        with:
-          name: target
-          path: target/ # or path/to/artifact

--- a/src/test/java/io/netty/incubator/codec/http3/AbtractHttp3ConnectionHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/AbtractHttp3ConnectionHandlerTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -62,7 +63,7 @@ public abstract class AbtractHttp3ConnectionHandlerTest {
         handler.channelRegistered(ctx);
         handler.channelActive(ctx);
 
-        assertEquals(localControlStreamChannel, Http3.getLocalControlStream(quicChannel));
+        assertNotEquals(localControlStreamChannel, Http3.getLocalControlStream(quicChannel));
 
         handler.channelInactive(ctx);
         handler.channelUnregistered(ctx);


### PR DESCRIPTION
Motivation:

On failure we should only try to collect surefire reports. The rest is not interesting for us.

Modifications:

Only add surefire reports

Result:

Less wasteful behavior