### PR TITLE
Only upload on build failures

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -41,4 +41,4 @@ jobs:
         if: ${{ failure() }}
         with:
           name: target
-          path: target/ # or path/to/artifact
+          path: "**/target/"

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -38,9 +38,3 @@ jobs:
 
       - name: Deploy project snapshot to sonatype
         run: docker-compose -f docker/docker-compose.centos-8.yaml -f docker/docker-compose.centos-8.18.yaml run deploy
-
-      - uses: actions/upload-artifact@v2
-        if: ${{ failure() }}
-        with:
-          name: target
-          path: target/ # or path/to/artifact


### PR DESCRIPTION
Motivation:

We should only upload target directories on build failure

Modifications:

- Only upload on build failure
- Make the matching more future-prove by also working with multi-module projects

Result:

Cleanup