### PR TITLE
Split build and pr workflow

### DIFF
--- a/.github/scripts/check_leak.sh
+++ b/.github/scripts/check_leak.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Expected build log as argument"
+    exit 1
+fi
+
+if grep -q 'LEAK:' $1 ; then
+    echo "Leak detected, please inspect build log"
+    exit 1
+else
+    echo "No Leak detected"
+    exit 0
+fi
+

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,8 +3,6 @@ name: Build project
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
   schedule:
     - cron: '30 8 * * 1'  # At 08:30 on Monday, every Monday.
@@ -22,33 +20,19 @@ jobs:
       - uses: satackey/action-docker-layer-caching@v0.0.8
         continue-on-error: true
         with:
-          key: build-docker-cache-{hash}
+          key: docker-cache-build-{hash}
           restore-keys: |
-            build-docker-cache-
+            docker-cache-build-
+            docker-cache-
 
       - name: Build docker image
         run: docker-compose -f docker/docker-compose.centos-8.yaml -f docker/docker-compose.centos-8.18.yaml build
 
       - name: Execute project build without leak detection
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: docker-compose -f docker/docker-compose.centos-8.yaml -f docker/docker-compose.centos-8.18.yaml run build
-
-      - name: Execute project build with leak detection
-        if: ${{ github.event_name == 'pull_request' }}
-        run: docker-compose -f docker/docker-compose.centos-8.yaml -f docker/docker-compose.centos-8.18.yaml run build-leak | tee build-leak.output
-
-      - name: Checking for detected leak
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          if grep -q 'LEAK:' build-leak.output ; then
-            echo "Leak detected, please inspect build log"
-            exit 1
-          else
-            echo "No Leak detected"
-          fi
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
           name: target
-          path: "**/target/" # or path/to/artifact
+          path: "**/target/"

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -29,9 +29,10 @@ jobs:
       - uses: satackey/action-docker-layer-caching@v0.0.8
         continue-on-error: true
         with:
-          key: deploy-docker-cache-{hash}
+          key: docker-cache-deploy-{hash}
           restore-keys: |
-            deploy-docker-cache-
+            docker-cache-deploy-
+            docker-cache-
 
       - name: Build docker image
         run: docker-compose -f docker/docker-compose.centos-8.yaml -f docker/docker-compose.centos-8.18.yaml build

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,63 @@
+name: Build project
+
+on:
+  pull_request:
+    branches: [ main ]
+
+  schedule:
+    - cron: '30 8 * * 1'  # At 08:30 on Monday, every Monday.
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        env:
+          cache-name: verify-cache-m2-repository
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-pr-${{ env.cache-name }}-
+            ${{ runner.os }}-pr-
+      - name: Verify with Maven
+        run: mvn verify -B --file pom.xml -DskipTests=true
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Enable caching of Docker layers
+      - uses: satackey/action-docker-layer-caching@v0.0.8
+        continue-on-error: true
+        with:
+          key: docker-cache-pr-build-{hash}
+          restore-keys: |
+            docker-cache-pr-build-
+            docker-cache-pr-
+            docker-cache-
+
+      - name: Build docker image
+        run: docker-compose -f docker/docker-compose.centos-8.yaml -f docker/docker-compose.centos-8.18.yaml build
+
+      - name: Execute project build with leak detection
+        run: docker-compose -f docker/docker-compose.centos-8.yaml -f docker/docker-compose.centos-8.18.yaml run build-leak | tee build-leak.output
+
+      - name: Checking for detected leak
+        run: ./.github/scripts/check_leak.sh build-leak.output
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: target
+          path: "**/target/"


### PR DESCRIPTION
Motivation:

We should better use seperate workflows for PR and normal builds

Modifications:

- Split workflows
- Better cache usage

Result:

Cleanup