### PR TITLE
Depend on verify job before trying to build a PR

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,4 +1,4 @@
-name: Build project
+name: Build PR
 
 on:
   pull_request:
@@ -31,6 +31,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    needs: verify
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Motivation:

Let's depend on a verify job before we try to build as this will fail fast for checkstyle etc

Modifications:

Let pr job only start once verify is done

Result:

Fail fast for checkstyle etc errors