### PR TITLE
Update action-docker-layer-caching

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.8
+      - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
         with:
           key: docker-cache-build-{hash}

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.8
+      - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
         with:
           key: docker-cache-deploy-{hash}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.8
+      - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
         with:
           key: docker-cache-pr-build-{hash}


### PR DESCRIPTION
Motivation:

We are three releases behind.

Modifications:

Update to latest version

Result:

Use up-to-date action-docker-layer-caching version