### PR TITLE
Use action to report unit test errors

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Execute project build without leak detection
         run: docker-compose -f docker/docker-compose.centos-8.yaml -f docker/docker-compose.centos-8.18.yaml run build
 
+      - name: build test-report
+        uses: scacap/action-surefire-report@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -51,6 +51,11 @@ jobs:
       - name: Execute project build with leak detection
         run: docker-compose -f docker/docker-compose.centos-8.yaml -f docker/docker-compose.centos-8.18.yaml run build-leak | tee build-leak.output
 
+      - name: build test-report
+        uses: scacap/action-surefire-report@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checking for detected leak
         run: ./.github/scripts/check_leak.sh build-leak.output
 


### PR DESCRIPTION
Motivation:

To make it easier to understand why the build fails lets use an action that will report which unit test failed

Modifications:

- Replace custom script with action-surefire-report

Result:

Easier to understand test failures