### PR TITLE
Upgrade to netty-incubator-codec-quic 0.0.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <skipTests>false</skipTests>
     <netty.version>4.1.59.Final</netty.version>
     <netty.build.version>28</netty.build.version>
-    <netty.quic.version>0.0.3.Final</netty.quic.version>
+    <netty.quic.version>0.0.4.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <test.argLine>-D_</test.argLine>
   </properties>

--- a/src/main/java/io/netty/incubator/codec/http3/Http3.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3.java
@@ -27,8 +27,6 @@ import io.netty.incubator.codec.quic.QuicStreamType;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
 
-import java.util.function.Supplier;
-
 /**
  * Contains utility methods that help to bootstrap server / clients with HTTP3 support.
  */
@@ -36,11 +34,11 @@ public final class Http3 {
 
     private Http3() {  }
 
-    private static final byte[] H3_PROTOS = new byte[] {
-            0x05, 'h', '3', '-', '2', '9',
-            0x05, 'h', '3', '-', '3', '0',
-            0x05, 'h', '3', '-', '3', '1',
-            0x05, 'h', '3', '-', '3', '2'
+    private static final String[] H3_PROTOS = new String[] {
+            "h3-29",
+            "h3-30",
+            "h3-31",
+            "h3-32"
     };
 
     private static final AttributeKey<QuicStreamChannel> HTTP3_CONTROL_STREAM_KEY =
@@ -116,7 +114,7 @@ public final class Http3 {
      *
      * @return the supported protocols.
      */
-    public static byte[] supportedApplicationProtocols() {
+    public static String[] supportedApplicationProtocols() {
         return H3_PROTOS.clone();
     }
 
@@ -153,7 +151,6 @@ public final class Http3 {
 
     private static <T extends QuicCodecBuilder<T>> T configure(T builder) {
         return builder.initialMaxStreamsUnidirectional(MIN_INITIAL_MAX_STREAMS_UNIDIRECTIONAL)
-                .initialMaxStreamDataUnidirectional(MIN_INITIAL_MAX_STREAM_DATA_UNIDIRECTIONAL)
-                .applicationProtocols(supportedApplicationProtocols());
+                .initialMaxStreamDataUnidirectional(MIN_INITIAL_MAX_STREAM_DATA_UNIDIRECTIONAL);
     }
 }

--- a/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicStreamChannel.java
+++ b/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicStreamChannel.java
@@ -30,6 +30,7 @@ import io.netty.incubator.codec.quic.QuicChannel;
 import io.netty.incubator.codec.quic.QuicStreamAddress;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.incubator.codec.quic.QuicStreamChannelConfig;
+import io.netty.incubator.codec.quic.QuicStreamPriority;
 import io.netty.incubator.codec.quic.QuicStreamType;
 
 import java.util.Map;
@@ -56,6 +57,16 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
         this.localCreated = localCreated;
         this.type = type;
         this.id = id;
+    }
+
+    @Override
+    public QuicStreamPriority priority() {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture updatePriority(QuicStreamPriority priority, ChannelPromise promise) {
+        return promise.setFailure(new UnsupportedOperationException());
     }
 
     @Override

--- a/src/test/java/io/netty/incubator/codec/http3/example/Http3ClientExample.java
+++ b/src/test/java/io/netty/incubator/codec/http3/example/Http3ClientExample.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.incubator.codec.http3.DefaultHttp3HeadersFrame;
 import io.netty.incubator.codec.http3.Http3;
 import io.netty.incubator.codec.http3.Http3ClientConnectionHandler;
@@ -29,6 +30,8 @@ import io.netty.incubator.codec.http3.Http3HeadersFrame;
 import io.netty.incubator.codec.http3.Http3RequestStreamFrame;
 import io.netty.incubator.codec.http3.Http3RequestStreamInboundHandler;
 import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.incubator.codec.quic.QuicSslContext;
+import io.netty.incubator.codec.quic.QuicSslContextBuilder;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
@@ -44,7 +47,11 @@ public final class Http3ClientExample {
         NioEventLoopGroup group = new NioEventLoopGroup(1);
 
         try {
+            QuicSslContext context = QuicSslContextBuilder.forClient()
+                    .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                    .applicationProtocols(Http3.supportedApplicationProtocols()).build();
             ChannelHandler codec = Http3.newQuicClientCodecBuilder()
+                    .sslContext(context)
                     .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
                     .initialMaxData(10000000)
                     .initialMaxStreamDataBidirectionalLocal(1000000)

--- a/src/test/java/io/netty/incubator/codec/http3/example/Http3ServerExample.java
+++ b/src/test/java/io/netty/incubator/codec/http3/example/Http3ServerExample.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.incubator.codec.http3.DefaultHttp3DataFrame;
 import io.netty.incubator.codec.http3.DefaultHttp3HeadersFrame;
 import io.netty.incubator.codec.http3.Http3;
@@ -32,6 +33,8 @@ import io.netty.incubator.codec.http3.Http3RequestStreamInboundHandler;
 import io.netty.incubator.codec.http3.Http3ServerConnectionHandler;
 import io.netty.incubator.codec.quic.InsecureQuicTokenHandler;
 import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.incubator.codec.quic.QuicSslContext;
+import io.netty.incubator.codec.quic.QuicSslContextBuilder;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
@@ -45,9 +48,11 @@ public final class Http3ServerExample {
 
     public static void main(String... args) throws Exception {
         NioEventLoopGroup group = new NioEventLoopGroup(1);
+        SelfSignedCertificate cert = new SelfSignedCertificate();
+        QuicSslContext sslContext = QuicSslContextBuilder.forServer(cert.key(), null, cert.cert())
+                .applicationProtocols(Http3.supportedApplicationProtocols()).build();
         ChannelHandler codec = Http3.newQuicServerCodecBuilder()
-                .certificateChain("./src/test/resources/cert.crt")
-                .privateKey("./src/test/resources/cert.key")
+                .sslContext(sslContext)
                 .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
                 .initialMaxData(10000000)
                 .initialMaxStreamDataBidirectionalLocal(1000000)


### PR DESCRIPTION
Motivation:

A new quic release was done.

Modifications:

Update to the latest QUIC release and adjust the code for the API changes

Result:

Use latest QUIC release