### PR TITLE
Update to netty-incubator-codec-quic 0.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <skipTests>false</skipTests>
     <netty.version>4.1.59.Final</netty.version>
     <netty.build.version>28</netty.build.version>
-    <netty.quic.version>0.0.4.Final</netty.quic.version>
+    <netty.quic.version>0.0.7.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <release.gpg.keyname/>
     <release.gpg.passphrase/>

--- a/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicStreamChannel.java
+++ b/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicStreamChannel.java
@@ -60,6 +60,18 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
     }
 
     @Override
+    public QuicStreamChannel flush() {
+        super.flush();
+        return this;
+    }
+
+    @Override
+    public QuicStreamChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
     public QuicStreamPriority priority() {
         return null;
     }


### PR DESCRIPTION
Motivation:

Let's update to the latest version of netty-incubator-codec-quic

Modifications:

Update to 0.0.7

Result:

Use latest version