### PR TITLE
Correctly validate for connection and te headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,11 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
       <version>${netty.version}</version>
     </dependency>

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ErrorCode.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ErrorCode.java
@@ -92,6 +92,11 @@ public enum Http3ErrorCode {
     H3_REQUEST_INCOMPLETE(0x10d),
 
     /**
+     * An HTTP message was malformed and cannot be processed.
+     */
+    H3_MESSAGE_ERROR(0x10e),
+
+    /**
      * The TCP connection established in response to a CONNECT request was reset or abnormally closed.
      */
     H3_CONNECT_ERROR(0x10f),

--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameDecoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameDecoder.java
@@ -18,6 +18,8 @@ package io.netty.incubator.codec.http3;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.incubator.codec.quic.QuicStreamFrame;
 import io.netty.util.internal.ObjectUtil;
 
@@ -144,6 +146,23 @@ final class Http3FrameDecoder extends ByteToMessageDecoder {
                 }
                 Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
                 if (decodeHeaders(ctx, headersFrame.headers(), in.readSlice(payLoadLength))) {
+                    if (headersFrame.headers().contains(HttpHeaderNames.CONNECTION)) {
+                        ctx.fireExceptionCaught(new Http3Exception(Http3ErrorCode.H3_MESSAGE_ERROR,
+                                "connection header included"));
+                        // We should close the stream.
+                        // See https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1.1
+                        ctx.close();
+                        return payLoadLength;
+                    }
+                    CharSequence value = headersFrame.headers().get(HttpHeaderNames.TE);
+                    if (value != null && !HttpHeaderValues.TRAILERS.equals(value)) {
+                        ctx.fireExceptionCaught(new Http3Exception(Http3ErrorCode.H3_MESSAGE_ERROR,
+                                "te header field included with invalid value: " + value));
+                        // We should close the stream.
+                        // See https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1.1
+                        ctx.close();
+                        return payLoadLength;
+                    }
                     out.add(headersFrame);
                 }
                 return payLoadLength;

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameEncoderDecoderTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameEncoderDecoderTest.java
@@ -23,6 +23,8 @@ import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.DefaultChannelId;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.incubator.codec.quic.QuicChannel;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -134,6 +136,38 @@ public class Http3FrameEncoderDecoderTest {
         settingsFrame.put(1073741823, 1073741823L);
         settingsFrame.put(4611686018427387903L, 4611686018427387903L);
         testFrameEncodedAndDecoded(settingsFrame);
+    }
+
+    @Test
+    public void testHttp3HeadersFrameWithConnectionHeader() {
+        Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
+        addRequestHeaders(headersFrame.headers());
+        headersFrame.headers().add(HttpHeaderNames.CONNECTION, "something");
+        try {
+            testFrameEncodedAndDecoded(headersFrame);
+        } catch (Exception e) {
+            assertException(Http3ErrorCode.H3_MESSAGE_ERROR, e);
+        }
+    }
+
+    @Test
+    public void testHttp3HeadersFrameWithTeHeaderAndInvalidValue() {
+        Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
+        addRequestHeaders(headersFrame.headers());
+        headersFrame.headers().add(HttpHeaderNames.TE, "something");
+        try {
+            testFrameEncodedAndDecoded(headersFrame);
+        } catch (Exception e) {
+            assertException(Http3ErrorCode.H3_MESSAGE_ERROR, e);
+        }
+    }
+
+    @Test
+    public void testHttp3HeadersFrameWithTeHeaderAndValidValue() {
+        Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
+        addRequestHeaders(headersFrame.headers());
+        headersFrame.headers().add(HttpHeaderNames.TE, HttpHeaderValues.TRAILERS);
+        testFrameEncodedAndDecoded(headersFrame);
     }
 
     @Test


### PR DESCRIPTION
Motivation:

We need to do some validation when it comes to connection and te headers. This commit does the validation and will handle these like documented in https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1.1.

Modifications:

- Correctly validate connection and te headers
- Add unit tests

Result:

More closely follow the RFC