### PR TITLE
Move all extra header validation to Http3RequestStreamValidationHandler

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameCodec.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameCodec.java
@@ -21,8 +21,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.ByteToMessageDecoder;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.incubator.codec.quic.QuicStreamFrame;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.ObjectUtil;
@@ -169,23 +167,6 @@ final class Http3FrameCodec extends ByteToMessageDecoder implements ChannelOutbo
                 }
                 Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
                 if (decodeHeaders(ctx, headersFrame.headers(), in.readSlice(payLoadLength))) {
-                    if (headersFrame.headers().contains(HttpHeaderNames.CONNECTION)) {
-                        ctx.fireExceptionCaught(new Http3Exception(Http3ErrorCode.H3_MESSAGE_ERROR,
-                                "connection header included"));
-                        // We should close the stream.
-                        // See https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1.1
-                        ctx.close();
-                        return payLoadLength;
-                    }
-                    CharSequence value = headersFrame.headers().get(HttpHeaderNames.TE);
-                    if (value != null && !HttpHeaderValues.TRAILERS.equals(value)) {
-                        ctx.fireExceptionCaught(new Http3Exception(Http3ErrorCode.H3_MESSAGE_ERROR,
-                                "te header field included with invalid value: " + value));
-                        // We should close the stream.
-                        // See https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1.1
-                        ctx.close();
-                        return payLoadLength;
-                    }
                     out.add(headersFrame);
                 }
                 return payLoadLength;

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameCodecTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameCodecTest.java
@@ -140,38 +140,6 @@ public class Http3FrameCodecTest {
     }
 
     @Test
-    public void testHttp3HeadersFrameWithConnectionHeader() {
-        Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
-        addRequestHeaders(headersFrame.headers());
-        headersFrame.headers().add(HttpHeaderNames.CONNECTION, "something");
-        try {
-            testFrameEncodedAndDecoded(headersFrame);
-        } catch (Exception e) {
-            assertException(Http3ErrorCode.H3_MESSAGE_ERROR, e);
-        }
-    }
-
-    @Test
-    public void testHttp3HeadersFrameWithTeHeaderAndInvalidValue() {
-        Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
-        addRequestHeaders(headersFrame.headers());
-        headersFrame.headers().add(HttpHeaderNames.TE, "something");
-        try {
-            testFrameEncodedAndDecoded(headersFrame);
-        } catch (Exception e) {
-            assertException(Http3ErrorCode.H3_MESSAGE_ERROR, e);
-        }
-    }
-
-    @Test
-    public void testHttp3HeadersFrameWithTeHeaderAndValidValue() {
-        Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
-        addRequestHeaders(headersFrame.headers());
-        headersFrame.headers().add(HttpHeaderNames.TE, HttpHeaderValues.TRAILERS);
-        testFrameEncodedAndDecoded(headersFrame);
-    }
-
-    @Test
     public void testHttp3HeadersFrame() {
         Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
         addRequestHeaders(headersFrame.headers());

--- a/src/test/java/io/netty/incubator/codec/http3/Http3TestUtils.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3TestUtils.java
@@ -48,7 +48,7 @@ final class Http3TestUtils {
         return parent;
     }
 
-    static void assertException(Http3ErrorCode code, Exception e) {
+    static void assertException(Http3ErrorCode code, Throwable e) {
         MatcherAssert.assertThat(e, CoreMatchers.instanceOf(Http3Exception.class));
         Http3Exception exception = (Http3Exception) e;
         assertEquals(code, exception.errorCode());


### PR DESCRIPTION
Motivation:

We already do some extra header validation in Http3RequestStreamValidationHandler, let's move all the logic there.

Modifications:

Move code from Http3FrameCodec to Http3RequestStreamValidationHandler

Result:

More consistent code