### PR TITLE
Add Http3FrameToHttpObjectCodec which converts between HTTP/3 - HTTP/1.1

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodec.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodec.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.incubator.codec.http3;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandler;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.EncoderException;
+import io.netty.handler.codec.UnsupportedMessageTypeException;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.FullHttpMessage;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpScheme;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.incubator.codec.quic.QuicStreamChannel;
+
+import java.net.SocketAddress;
+
+/**
+ * This handler converts from {@link Http3RequestStreamFrame} to {@link HttpObject},
+ * and back. It can be used as an adapter in conjunction with {@link
+ * Http3ServerConnectionHandler} or {@link Http3ClientConnectionHandler} to make http/3 connections
+ * backward-compatible with {@link ChannelHandler}s expecting {@link HttpObject}.
+ *
+ * For simplicity, it converts to chunked encoding unless the entire stream
+ * is a single header.
+ */
+public final class Http3FrameToHttpObjectCodec extends Http3RequestStreamInboundHandler
+        implements ChannelOutboundHandler {
+
+    private final boolean isServer;
+    private final boolean validateHeaders;
+
+    public Http3FrameToHttpObjectCodec(final boolean isServer,
+                                       final boolean validateHeaders) {
+        this.isServer = isServer;
+        this.validateHeaders = validateHeaders;
+    }
+
+    public Http3FrameToHttpObjectCodec(final boolean isServer) {
+        this(isServer, true);
+    }
+
+    @Override
+    protected void channelRead(ChannelHandlerContext ctx, Http3HeadersFrame frame, boolean isLast) throws Exception {
+        Http3Headers headers = frame.headers();
+        long id = ((QuicStreamChannel) ctx.channel()).streamId();
+
+        final CharSequence status = headers.status();
+
+        // 100-continue response is a special case where we should not send a fin,
+        // but we need to decode it as a FullHttpResponse to play nice with HttpObjectAggregator.
+        if (null != status && HttpResponseStatus.CONTINUE.codeAsText().contentEquals(status)) {
+            final FullHttpMessage fullMsg = newFullMessage(id, headers, ctx.alloc());
+            ctx.fireChannelRead(fullMsg);
+            return;
+        }
+
+        if (isLast) {
+            if (headers.method() == null && status == null) {
+                LastHttpContent last = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER, validateHeaders);
+                HttpConversionUtil.addHttp3ToHttpHeaders(id, headers, last.trailingHeaders(),
+                        HttpVersion.HTTP_1_1, true, true);
+                ctx.fireChannelRead(last);
+            } else {
+                FullHttpMessage full = newFullMessage(id, headers, ctx.alloc());
+                ctx.fireChannelRead(full);
+            }
+        } else {
+            HttpMessage req = newMessage(id, headers);
+            if (!HttpUtil.isContentLengthSet(req)) {
+                req.headers().add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+            }
+            ctx.fireChannelRead(req);
+        }
+    }
+
+    @Override
+    protected void channelRead(ChannelHandlerContext ctx, Http3DataFrame frame, boolean isLast) throws Exception {
+        if (isLast) {
+            ctx.fireChannelRead(new DefaultLastHttpContent(frame.content()));
+        } else {
+            ctx.fireChannelRead(new DefaultHttpContent(frame.content()));
+        }
+    }
+
+    /**
+     * Encode from an {@link HttpObject} to an {@link Http3RequestStreamFrame}. This method will
+     * be called for each written message that can be handled by this encoder.
+     *
+     * NOTE: 100-Continue responses that are NOT {@link FullHttpResponse} will be rejected.
+     *
+     * @param ctx           the {@link ChannelHandlerContext} which this handler belongs to
+     * @param msg           the {@link HttpObject} message to encode
+     * @throws Exception    is thrown if an error occurs
+     */
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (!(msg instanceof HttpObject)) {
+            throw new UnsupportedMessageTypeException();
+        }
+        // 100-continue is typically a FullHttpResponse, but the decoded
+        // Http3HeadersFrame should not handles as a end of stream.
+        if (msg instanceof HttpResponse) {
+            final HttpResponse res = (HttpResponse) msg;
+            if (res.status().equals(HttpResponseStatus.CONTINUE)) {
+                if (res instanceof FullHttpResponse) {
+                    final Http3Headers headers = toHttp3Headers(res);
+                    ctx.write(new DefaultHttp3HeadersFrame(headers));
+                    ((FullHttpResponse) res).release();
+                    return;
+                } else {
+                    throw new EncoderException(
+                            HttpResponseStatus.CONTINUE.toString() + " must be a FullHttpResponse");
+                }
+            }
+        }
+
+        ChannelFuture future = null;
+        if (msg instanceof HttpMessage) {
+            Http3Headers headers = toHttp3Headers((HttpMessage) msg);
+             future = ctx.write(new DefaultHttp3HeadersFrame(headers));
+        }
+
+        if (msg instanceof LastHttpContent) {
+            LastHttpContent last = (LastHttpContent) msg;
+            boolean readable = last.content().isReadable();
+            boolean hasTrailers = !last.trailingHeaders().isEmpty();
+
+            if (future != null && !readable && !hasTrailers) {
+                future.addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
+                last.release();
+            } else {
+                if (readable && !hasTrailers) {
+                    ctx.write(new DefaultHttp3DataFrame(last.content())).addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
+                } else if (!readable) {
+                    Http3Headers headers = HttpConversionUtil.toHttp3Headers(last.trailingHeaders(), validateHeaders);
+                    ctx.write(new DefaultHttp3HeadersFrame(headers)).addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
+                    last.release();
+                } else {
+                    ctx.write(new DefaultHttp3DataFrame(last.content()));
+                    Http3Headers headers = HttpConversionUtil.toHttp3Headers(last.trailingHeaders(), validateHeaders);
+                    ctx.write(new DefaultHttp3HeadersFrame(headers)).addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
+                }
+            }
+        } else if (msg instanceof HttpContent) {
+            ctx.write(new DefaultHttp3DataFrame(((HttpContent) msg).content()));
+        }
+    }
+
+    private Http3Headers toHttp3Headers(HttpMessage msg) {
+        if (msg instanceof HttpRequest) {
+            msg.headers().set(
+                    HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), HttpScheme.HTTPS);
+        }
+
+        return HttpConversionUtil.toHttp3Headers(msg, validateHeaders);
+    }
+
+    private HttpMessage newMessage(final long id,
+                                   final Http3Headers headers) throws Http3Exception {
+        return isServer ?
+                HttpConversionUtil.toHttpRequest(id, headers, validateHeaders) :
+                HttpConversionUtil.toHttpResponse(id, headers, validateHeaders);
+    }
+
+    private FullHttpMessage newFullMessage(final long id,
+                                           final Http3Headers headers,
+                                           final ByteBufAllocator alloc) throws Http3Exception {
+        return isServer ?
+                HttpConversionUtil.toFullHttpRequest(id, headers, alloc, validateHeaders) :
+                HttpConversionUtil.toFullHttpResponse(id, headers, alloc, validateHeaders);
+    }
+
+    @Override
+    public void flush(ChannelHandlerContext ctx) {
+        ctx.flush();
+    }
+
+    @Override
+    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
+        ctx.bind(localAddress, promise);
+    }
+
+    @Override
+    public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress,
+                        SocketAddress localAddress, ChannelPromise promise) {
+        ctx.connect(remoteAddress, localAddress, promise);
+    }
+
+    @Override
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
+        ctx.disconnect(promise);
+    }
+
+    @Override
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
+        ctx.close(promise);
+    }
+
+    @Override
+    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
+        ctx.deregister(promise);
+    }
+
+    @Override
+    public void read(ChannelHandlerContext ctx) throws Exception {
+        ctx.read();
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/http3/HttpConversionUtil.java
+++ b/src/main/java/io/netty/incubator/codec/http3/HttpConversionUtil.java
@@ -1,0 +1,632 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.codec.UnsupportedValueConverter;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.FullHttpMessage;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.AsciiString;
+import io.netty.util.internal.InternalThreadLocalMap;
+
+import java.net.URI;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.COOKIE;
+import static io.netty.handler.codec.http.HttpHeaderNames.TE;
+import static io.netty.handler.codec.http.HttpHeaderValues.TRAILERS;
+import static io.netty.handler.codec.http.HttpResponseStatus.parseLine;
+import static io.netty.handler.codec.http.HttpScheme.HTTP;
+import static io.netty.handler.codec.http.HttpScheme.HTTPS;
+import static io.netty.handler.codec.http.HttpUtil.isAsteriskForm;
+import static io.netty.handler.codec.http.HttpUtil.isOriginForm;
+import static io.netty.util.AsciiString.EMPTY_STRING;
+import static io.netty.util.AsciiString.contentEqualsIgnoreCase;
+import static io.netty.util.AsciiString.indexOf;
+import static io.netty.util.AsciiString.trim;
+import static io.netty.util.ByteProcessor.FIND_COMMA;
+import static io.netty.util.ByteProcessor.FIND_SEMI_COLON;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.StringUtil.isNullOrEmpty;
+import static io.netty.util.internal.StringUtil.length;
+import static io.netty.util.internal.StringUtil.unescapeCsvFields;
+
+/**
+ * Provides utility methods and constants for the HTTP/3 to HTTP conversion
+ */
+public final class HttpConversionUtil {
+    /**
+     * The set of headers that should not be directly copied when converting headers from HTTP to HTTP/3.
+     */
+    private static final CharSequenceMap<AsciiString> HTTP_TO_HTTP3_HEADER_BLACKLIST =
+            new CharSequenceMap<>();
+    static {
+        HTTP_TO_HTTP3_HEADER_BLACKLIST.add(CONNECTION, EMPTY_STRING);
+        @SuppressWarnings("deprecation")
+        AsciiString keepAlive = HttpHeaderNames.KEEP_ALIVE;
+        HTTP_TO_HTTP3_HEADER_BLACKLIST.add(keepAlive, EMPTY_STRING);
+        @SuppressWarnings("deprecation")
+        AsciiString proxyConnection = HttpHeaderNames.PROXY_CONNECTION;
+        HTTP_TO_HTTP3_HEADER_BLACKLIST.add(proxyConnection, EMPTY_STRING);
+        HTTP_TO_HTTP3_HEADER_BLACKLIST.add(HttpHeaderNames.TRANSFER_ENCODING, EMPTY_STRING);
+        HTTP_TO_HTTP3_HEADER_BLACKLIST.add(HttpHeaderNames.HOST, EMPTY_STRING);
+        HTTP_TO_HTTP3_HEADER_BLACKLIST.add(HttpHeaderNames.UPGRADE, EMPTY_STRING);
+        HTTP_TO_HTTP3_HEADER_BLACKLIST.add(ExtensionHeaderNames.STREAM_ID.text(), EMPTY_STRING);
+        HTTP_TO_HTTP3_HEADER_BLACKLIST.add(ExtensionHeaderNames.SCHEME.text(), EMPTY_STRING);
+        HTTP_TO_HTTP3_HEADER_BLACKLIST.add(ExtensionHeaderNames.PATH.text(), EMPTY_STRING);
+    }
+
+    /**
+     * <a href="https://tools.ietf.org/html/rfc7540#section-8.1.2.3">[RFC 7540], 8.1.2.3</a> states the path must not
+     * be empty, and instead should be {@code /}.
+     */
+    private static final AsciiString EMPTY_REQUEST_PATH = AsciiString.cached("/");
+
+    private HttpConversionUtil() {
+    }
+
+    /**
+     * Provides the HTTP header extensions used to carry HTTP/3 information in HTTP objects
+     */
+    public enum ExtensionHeaderNames {
+        /**
+         * HTTP extension header which will identify the stream id from the HTTP/3 event(s) responsible for
+         * generating an {@code HttpObject}
+         * <p>
+         * {@code "x-http3-stream-id"}
+         */
+        STREAM_ID("x-http3-stream-id"),
+        /**
+         * HTTP extension header which will identify the scheme pseudo header from the HTTP/3 event(s) responsible for
+         * generating an {@code HttpObject}
+         * <p>
+         * {@code "x-http3-scheme"}
+         */
+        SCHEME("x-http3-scheme"),
+        /**
+         * HTTP extension header which will identify the path pseudo header from the HTTP/3 event(s) responsible for
+         * generating an {@code HttpObject}
+         * <p>
+         * {@code "x-http3-path"}
+         */
+        PATH("x-http3-path"),
+        /**
+         * HTTP extension header which will identify the stream id used to create this stream in an HTTP/3 push promise
+         * frame
+         * <p>
+         * {@code "x-http3-stream-promise-id"}
+         */
+        STREAM_PROMISE_ID("x-http3-stream-promise-id");
+
+        private final AsciiString text;
+
+        ExtensionHeaderNames(String text) {
+            this.text = AsciiString.cached(text);
+        }
+
+        public AsciiString text() {
+            return text;
+        }
+    }
+
+    /**
+     * Apply HTTP/3 rules while translating status code to {@link HttpResponseStatus}
+     *
+     * @param status The status from an HTTP/3 frame
+     * @return The HTTP/1.x status
+     * @throws Http3Exception If there is a problem translating from HTTP/3 to HTTP/1.x
+     */
+    private static HttpResponseStatus parseStatus(long streamId, CharSequence status) throws Http3Exception {
+        HttpResponseStatus result;
+        try {
+            result = parseLine(status);
+            if (result == HttpResponseStatus.SWITCHING_PROTOCOLS) {
+                throw streamError(streamId, Http3ErrorCode.H3_MESSAGE_ERROR,
+                        "Invalid HTTP/3 status code '" + status + "'", null);
+            }
+        } catch (Http3Exception e) {
+            throw e;
+        } catch (Throwable t) {
+            throw streamError(streamId, Http3ErrorCode.H3_MESSAGE_ERROR, "Unrecognized HTTP status code '"
+                    + status + "' encountered in translation to HTTP/1.x" + status, null);
+        }
+        return result;
+    }
+
+    /**
+     * Create a new object to contain the response data
+     *
+     * @param streamId The stream associated with the response
+     * @param http3Headers The initial set of HTTP/3 headers to create the response with
+     * @param alloc The {@link ByteBufAllocator} to use to generate the content of the message
+     * @param validateHttpHeaders <ul>
+     *        <li>{@code true} to validate HTTP headers in the http-codec</li>
+     *        <li>{@code false} not to validate HTTP headers in the http-codec</li>
+     *        </ul>
+     * @return A new response object which represents headers/data
+     * @throws Http3Exception
+     */
+    static FullHttpResponse toFullHttpResponse(long streamId, Http3Headers http3Headers, ByteBufAllocator alloc,
+                                                      boolean validateHttpHeaders) throws Http3Exception {
+        ByteBuf content = alloc.buffer();
+        HttpResponseStatus status = parseStatus(streamId, http3Headers.status());
+        // HTTP/3 does not define a way to carry the version or reason phrase that is included in an
+        // HTTP/1.1 status line.
+        FullHttpResponse msg = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status, content,
+                                                           validateHttpHeaders);
+        try {
+            addHttp3ToHttpHeaders(streamId, http3Headers, msg, false);
+        } catch (Http3Exception e) {
+            msg.release();
+            throw e;
+        } catch (Throwable t) {
+            msg.release();
+            throw streamError(streamId, Http3ErrorCode.H3_MESSAGE_ERROR,
+                    "HTTP/3 to HTTP/1.x headers conversion error", t);
+        }
+        return msg;
+    }
+
+    /**
+     * Create a new object to contain the request data
+     *
+     * @param streamId The stream associated with the request
+     * @param http3Headers The initial set of HTTP/3 headers to create the request with
+     * @param alloc The {@link ByteBufAllocator} to use to generate the content of the message
+     * @param validateHttpHeaders <ul>
+     *        <li>{@code true} to validate HTTP headers in the http-codec</li>
+     *        <li>{@code false} not to validate HTTP headers in the http-codec</li>
+     *        </ul>
+     * @return A new request object which represents headers/data
+     * @throws Http3Exception
+     */
+    static FullHttpRequest toFullHttpRequest(long streamId, Http3Headers http3Headers, ByteBufAllocator alloc,
+                                                    boolean validateHttpHeaders) throws Http3Exception {
+        ByteBuf content = alloc.buffer();
+        // HTTP/3 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line.
+        final CharSequence method = checkNotNull(http3Headers.method(),
+                "method header cannot be null in conversion to HTTP/1.x");
+        final CharSequence path = checkNotNull(http3Headers.path(),
+                "path header cannot be null in conversion to HTTP/1.x");
+        FullHttpRequest msg = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.valueOf(method
+                        .toString()), path.toString(), content, validateHttpHeaders);
+        try {
+            addHttp3ToHttpHeaders(streamId, http3Headers, msg, false);
+        } catch (Http3Exception e) {
+            msg.release();
+            throw e;
+        } catch (Throwable t) {
+            msg.release();
+            throw streamError(streamId, Http3ErrorCode.H3_MESSAGE_ERROR,
+                    "HTTP/3 to HTTP/1.x headers conversion error", t);
+        }
+        return msg;
+    }
+
+    /**
+     * Create a new object to contain the request data.
+     *
+     * @param streamId The stream associated with the request
+     * @param http3Headers The initial set of HTTP/3 headers to create the request with
+     * @param validateHttpHeaders <ul>
+     *        <li>{@code true} to validate HTTP headers in the http-codec</li>
+     *        <li>{@code false} not to validate HTTP headers in the http-codec</li>
+     *        </ul>
+     * @return A new request object which represents headers for a chunked request
+     * @throws Http3Exception
+     */
+    static HttpRequest toHttpRequest(long streamId, Http3Headers http3Headers, boolean validateHttpHeaders)
+                    throws Http3Exception {
+        // HTTP/3 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line.
+        final CharSequence method = checkNotNull(http3Headers.method(),
+                "method header cannot be null in conversion to HTTP/1.x");
+        final CharSequence path = checkNotNull(http3Headers.path(),
+                "path header cannot be null in conversion to HTTP/1.x");
+        HttpRequest msg = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.valueOf(method.toString()),
+                path.toString(), validateHttpHeaders);
+        try {
+            addHttp3ToHttpHeaders(streamId, http3Headers, msg.headers(), msg.protocolVersion(), false, true);
+        } catch (Http3Exception e) {
+            throw e;
+        } catch (Throwable t) {
+            throw streamError(streamId, Http3ErrorCode.H3_MESSAGE_ERROR,
+                    "HTTP/3 to HTTP/1.x headers conversion error", t);
+        }
+        return msg;
+    }
+
+    /**
+     * Create a new object to contain the response data.
+     *
+     * @param streamId The stream associated with the response
+     * @param http3Headers The initial set of HTTP/3 headers to create the response with
+     * @param validateHttpHeaders <ul>
+     *        <li>{@code true} to validate HTTP headers in the http-codec</li>
+     *        <li>{@code false} not to validate HTTP headers in the http-codec</li>
+     *        </ul>
+     * @return A new response object which represents headers for a chunked response
+     * @throws Http3Exception
+     */
+    static HttpResponse toHttpResponse(final long streamId,
+                                              final Http3Headers http3Headers,
+                                              final boolean validateHttpHeaders) throws Http3Exception {
+        final HttpResponseStatus status = parseStatus(streamId, http3Headers.status());
+        // HTTP/3 does not define a way to carry the version or reason phrase that is included in an
+        // HTTP/1.1 status line.
+        final HttpResponse msg = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status, validateHttpHeaders);
+        try {
+            addHttp3ToHttpHeaders(streamId, http3Headers, msg.headers(), msg.protocolVersion(), false, false);
+        } catch (final Http3Exception e) {
+            throw e;
+        } catch (final Throwable t) {
+            throw streamError(streamId, Http3ErrorCode.H3_MESSAGE_ERROR,
+                    "HTTP/3 to HTTP/1.x headers conversion error", t);
+        }
+        return msg;
+    }
+
+    /**
+     * Translate and add HTTP/3 headers to HTTP/1.x headers.
+     *
+     * @param streamId The stream associated with {@code sourceHeaders}.
+     * @param inputHeaders The HTTP/3 headers to convert.
+     * @param destinationMessage The object which will contain the resulting HTTP/1.x headers.
+     * @param addToTrailer {@code true} to add to trailing headers. {@code false} to add to initial headers.
+     * @throws Http3Exception If not all HTTP/3 headers can be translated to HTTP/1.x.
+     */
+    private static void addHttp3ToHttpHeaders(long streamId, Http3Headers inputHeaders,
+                    FullHttpMessage destinationMessage, boolean addToTrailer) throws Http3Exception {
+        addHttp3ToHttpHeaders(streamId, inputHeaders,
+                addToTrailer ? destinationMessage.trailingHeaders() : destinationMessage.headers(),
+                destinationMessage.protocolVersion(), addToTrailer, destinationMessage instanceof HttpRequest);
+    }
+
+    /**
+     * Translate and add HTTP/3 headers to HTTP/1.x headers.
+     *
+     * @param streamId The stream associated with {@code sourceHeaders}.
+     * @param inputHeaders The HTTP/3 headers to convert.
+     * @param outputHeaders The object which will contain the resulting HTTP/1.x headers..
+     * @param httpVersion What HTTP/1.x version {@code outputHeaders} should be treated as when doing the conversion.
+     * @param isTrailer {@code true} if {@code outputHeaders} should be treated as trailing headers.
+     * {@code false} otherwise.
+     * @param isRequest {@code true} if the {@code outputHeaders} will be used in a request message.
+     * {@code false} for response message.
+     * @throws Http3Exception If not all HTTP/3 headers can be translated to HTTP/1.x.
+     */
+     static void addHttp3ToHttpHeaders(long streamId, Http3Headers inputHeaders, HttpHeaders outputHeaders,
+            HttpVersion httpVersion, boolean isTrailer, boolean isRequest) throws Http3Exception {
+         Http3ToHttpHeaderTranslator translator = new Http3ToHttpHeaderTranslator(streamId, outputHeaders, isRequest);
+        try {
+            translator.translateHeaders(inputHeaders);
+        } catch (Http3Exception ex) {
+            throw ex;
+        } catch (Throwable t) {
+            throw streamError(streamId, Http3ErrorCode.H3_MESSAGE_ERROR,
+                    "HTTP/3 to HTTP/1.x headers conversion error", t);
+        }
+
+        outputHeaders.remove(HttpHeaderNames.TRANSFER_ENCODING);
+        outputHeaders.remove(HttpHeaderNames.TRAILER);
+        if (!isTrailer) {
+            outputHeaders.set(ExtensionHeaderNames.STREAM_ID.text(), streamId);
+            HttpUtil.setKeepAlive(outputHeaders, httpVersion, true);
+        }
+    }
+
+    /**
+     * Converts the given HTTP/1.x headers into HTTP/3 headers.
+     * The following headers are only used if they can not be found in from the {@code HOST} header or the
+     * {@code Request-Line} as defined by <a href="https://tools.ietf.org/html/rfc7230">rfc7230</a>
+     * <ul>
+     * <li>{@link ExtensionHeaderNames#SCHEME}</li>
+     * </ul>
+     * {@link ExtensionHeaderNames#PATH} is ignored and instead extracted from the {@code Request-Line}.
+     */
+    static Http3Headers toHttp3Headers(HttpMessage in, boolean validateHeaders) {
+        HttpHeaders inHeaders = in.headers();
+        final Http3Headers out = new DefaultHttp3Headers(validateHeaders, inHeaders.size());
+        if (in instanceof HttpRequest) {
+            HttpRequest request = (HttpRequest) in;
+            URI requestTargetUri = URI.create(request.uri());
+            out.path(toHttp3Path(requestTargetUri));
+            out.method(request.method().asciiName());
+            setHttp3Scheme(inHeaders, requestTargetUri, out);
+
+            if (!isOriginForm(requestTargetUri) && !isAsteriskForm(requestTargetUri)) {
+                // Attempt to take from HOST header before taking from the request-line
+                String host = inHeaders.getAsString(HttpHeaderNames.HOST);
+                setHttp3Authority((host == null || host.isEmpty()) ? requestTargetUri.getAuthority() : host, out);
+            }
+        } else if (in instanceof HttpResponse) {
+            HttpResponse response = (HttpResponse) in;
+            out.status(response.status().codeAsText());
+        }
+
+        // Add the HTTP headers which have not been consumed above
+        toHttp3Headers(inHeaders, out);
+        return out;
+    }
+
+    static Http3Headers toHttp3Headers(HttpHeaders inHeaders, boolean validateHeaders) {
+        if (inHeaders.isEmpty()) {
+            return new DefaultHttp3Headers();
+        }
+
+        final Http3Headers out = new DefaultHttp3Headers(validateHeaders, inHeaders.size());
+        toHttp3Headers(inHeaders, out);
+        return out;
+    }
+
+    private static CharSequenceMap<AsciiString> toLowercaseMap(Iterator<? extends CharSequence> valuesIter,
+                                                               int arraySizeHint) {
+        UnsupportedValueConverter<AsciiString> valueConverter = UnsupportedValueConverter.<AsciiString>instance();
+        CharSequenceMap<AsciiString> result = new CharSequenceMap<AsciiString>(true, valueConverter, arraySizeHint);
+
+        while (valuesIter.hasNext()) {
+            AsciiString lowerCased = AsciiString.of(valuesIter.next()).toLowerCase();
+            try {
+                int index = lowerCased.forEachByte(FIND_COMMA);
+                if (index != -1) {
+                    int start = 0;
+                    do {
+                        result.add(lowerCased.subSequence(start, index, false).trim(), EMPTY_STRING);
+                        start = index + 1;
+                    } while (start < lowerCased.length() &&
+                             (index = lowerCased.forEachByte(start, lowerCased.length() - start, FIND_COMMA)) != -1);
+                    result.add(lowerCased.subSequence(start, lowerCased.length(), false).trim(), EMPTY_STRING);
+                } else {
+                    result.add(lowerCased.trim(), EMPTY_STRING);
+                }
+            } catch (Exception e) {
+                // This is not expect to happen because FIND_COMMA never throws but must be caught
+                // because of the ByteProcessor interface.
+                throw new IllegalStateException(e);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Filter the {@link HttpHeaderNames#TE} header according to the
+     * <a href="https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1.1">
+     *     special rules in the HTTP/3 RFC</a>.
+     * @param entry An entry whose name is {@link HttpHeaderNames#TE}.
+     * @param out the resulting HTTP/3 headers.
+     */
+    private static void toHttp3HeadersFilterTE(Entry<CharSequence, CharSequence> entry,
+                                               Http3Headers out) {
+        if (indexOf(entry.getValue(), ',', 0) == -1) {
+            if (contentEqualsIgnoreCase(trim(entry.getValue()), TRAILERS)) {
+                out.add(TE, TRAILERS);
+            }
+        } else {
+            List<CharSequence> teValues = unescapeCsvFields(entry.getValue());
+            for (CharSequence teValue : teValues) {
+                if (contentEqualsIgnoreCase(trim(teValue), TRAILERS)) {
+                    out.add(TE, TRAILERS);
+                    break;
+                }
+            }
+        }
+    }
+
+    static void toHttp3Headers(HttpHeaders inHeaders, Http3Headers out) {
+        Iterator<Entry<CharSequence, CharSequence>> iter = inHeaders.iteratorCharSequence();
+        // Choose 8 as a default size because it is unlikely we will see more than 4 Connection headers values, but
+        // still allowing for "enough" space in the map to reduce the chance of hash code collision.
+        CharSequenceMap<AsciiString> connectionBlacklist =
+            toLowercaseMap(inHeaders.valueCharSequenceIterator(CONNECTION), 8);
+        while (iter.hasNext()) {
+            Entry<CharSequence, CharSequence> entry = iter.next();
+            final AsciiString aName = AsciiString.of(entry.getKey()).toLowerCase();
+            if (!HTTP_TO_HTTP3_HEADER_BLACKLIST.contains(aName) && !connectionBlacklist.contains(aName)) {
+                // https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1.1 makes a special exception
+                // for TE
+                if (aName.contentEqualsIgnoreCase(TE)) {
+                    toHttp3HeadersFilterTE(entry, out);
+                } else if (aName.contentEqualsIgnoreCase(COOKIE)) {
+                    AsciiString value = AsciiString.of(entry.getValue());
+                    // split up cookies to allow for better compression
+                    try {
+                        int index = value.forEachByte(FIND_SEMI_COLON);
+                        if (index != -1) {
+                            int start = 0;
+                            do {
+                                out.add(COOKIE, value.subSequence(start, index, false));
+                                // skip 2 characters "; " (see https://tools.ietf.org/html/rfc6265#section-4.2.1)
+                                start = index + 2;
+                            } while (start < value.length() &&
+                                    (index = value.forEachByte(start, value.length() - start, FIND_SEMI_COLON)) != -1);
+                            if (start >= value.length()) {
+                                throw new IllegalArgumentException("cookie value is of unexpected format: " + value);
+                            }
+                            out.add(COOKIE, value.subSequence(start, value.length(), false));
+                        } else {
+                            out.add(COOKIE, value);
+                        }
+                    } catch (Exception e) {
+                        // This is not expect to happen because FIND_SEMI_COLON never throws but must be caught
+                        // because of the ByteProcessor interface.
+                        throw new IllegalStateException(e);
+                    }
+                } else {
+                    out.add(aName, entry.getValue());
+                }
+            }
+        }
+    }
+
+    /**
+     * Generate an HTTP/3 {code :path} from a URI in accordance with
+     * <a href="https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1.1.1">HTTP3 spec</a>.
+     */
+    private static AsciiString toHttp3Path(URI uri) {
+        StringBuilder pathBuilder = new StringBuilder(length(uri.getRawPath()) +
+                length(uri.getRawQuery()) + length(uri.getRawFragment()) + 2);
+        if (!isNullOrEmpty(uri.getRawPath())) {
+            pathBuilder.append(uri.getRawPath());
+        }
+        if (!isNullOrEmpty(uri.getRawQuery())) {
+            pathBuilder.append('?');
+            pathBuilder.append(uri.getRawQuery());
+        }
+        if (!isNullOrEmpty(uri.getRawFragment())) {
+            pathBuilder.append('#');
+            pathBuilder.append(uri.getRawFragment());
+        }
+        String path = pathBuilder.toString();
+        return path.isEmpty() ? EMPTY_REQUEST_PATH : new AsciiString(path);
+    }
+
+    // package-private for testing only
+    static void setHttp3Authority(String authority, Http3Headers out) {
+        // The authority MUST NOT include the deprecated "userinfo" subcomponent
+        if (authority != null) {
+            if (authority.isEmpty()) {
+                out.authority(EMPTY_STRING);
+            } else {
+                int start = authority.indexOf('@') + 1;
+                int length = authority.length() - start;
+                if (length == 0) {
+                    throw new IllegalArgumentException("authority: " + authority);
+                }
+                out.authority(new AsciiString(authority, start, length));
+            }
+        }
+    }
+
+    private static void setHttp3Scheme(HttpHeaders in, URI uri, Http3Headers out) {
+        String value = uri.getScheme();
+        if (value != null) {
+            out.scheme(new AsciiString(value));
+            return;
+        }
+
+        // Consume the Scheme extension header if present
+        CharSequence cValue = in.get(ExtensionHeaderNames.SCHEME.text());
+        if (cValue != null) {
+            out.scheme(AsciiString.of(cValue));
+            return;
+        }
+
+        if (uri.getPort() == HTTPS.port()) {
+            out.scheme(HTTPS.name());
+        } else if (uri.getPort() == HTTP.port()) {
+            out.scheme(HTTP.name());
+        } else {
+            throw new IllegalArgumentException(":scheme must be specified. " +
+                    "see https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1.1.1");
+        }
+    }
+
+    /**
+     * Utility which translates HTTP/3 headers to HTTP/1 headers.
+     */
+    private static final class Http3ToHttpHeaderTranslator {
+        /**
+         * Translations from HTTP/3 header name to the HTTP/1.x equivalent.
+         */
+        private static final CharSequenceMap<AsciiString>
+            REQUEST_HEADER_TRANSLATIONS = new CharSequenceMap<AsciiString>();
+        private static final CharSequenceMap<AsciiString>
+            RESPONSE_HEADER_TRANSLATIONS = new CharSequenceMap<AsciiString>();
+        static {
+            RESPONSE_HEADER_TRANSLATIONS.add(Http3Headers.PseudoHeaderName.AUTHORITY.value(),
+                            HttpHeaderNames.HOST);
+            RESPONSE_HEADER_TRANSLATIONS.add(Http3Headers.PseudoHeaderName.SCHEME.value(),
+                            ExtensionHeaderNames.SCHEME.text());
+            REQUEST_HEADER_TRANSLATIONS.add(RESPONSE_HEADER_TRANSLATIONS);
+            RESPONSE_HEADER_TRANSLATIONS.add(Http3Headers.PseudoHeaderName.PATH.value(),
+                            ExtensionHeaderNames.PATH.text());
+        }
+
+        private final long streamId;
+        private final HttpHeaders output;
+        private final CharSequenceMap<AsciiString> translations;
+
+        /**
+         * Create a new instance
+         *
+         * @param output The HTTP/1.x headers object to store the results of the translation
+         * @param request if {@code true}, translates headers using the request translation map. Otherwise uses the
+         *        response translation map.
+         */
+        Http3ToHttpHeaderTranslator(long streamId, HttpHeaders output, boolean request) {
+            this.streamId = streamId;
+            this.output = output;
+            translations = request ? REQUEST_HEADER_TRANSLATIONS : RESPONSE_HEADER_TRANSLATIONS;
+        }
+
+        void translateHeaders(Iterable<Entry<CharSequence, CharSequence>> inputHeaders) throws Http3Exception {
+            // lazily created as needed
+            StringBuilder cookies = null;
+
+            for (Entry<CharSequence, CharSequence> entry : inputHeaders) {
+                final CharSequence name = entry.getKey();
+                final CharSequence value = entry.getValue();
+                AsciiString translatedName = translations.get(name);
+                if (translatedName != null) {
+                    output.add(translatedName, AsciiString.of(value));
+                } else if (!Http3Headers.PseudoHeaderName.isPseudoHeader(name)) {
+                    // https://tools.ietf.org/html/rfc7540#section-8.1.2.3
+                    // All headers that start with ':' are only valid in HTTP/3 context
+                    if (name.length() == 0 || name.charAt(0) == ':') {
+                        throw streamError(streamId, Http3ErrorCode.H3_MESSAGE_ERROR,
+                                "Invalid HTTP/3 header '" + name + "' encountered in translation to HTTP/1.x",
+                                null);
+                    }
+                    if (COOKIE.equals(name)) {
+                        // combine the cookie values into 1 header entry.
+                        // https://tools.ietf.org/html/rfc7540#section-8.1.2.5
+                        if (cookies == null) {
+                            cookies = InternalThreadLocalMap.get().stringBuilder();
+                        } else if (cookies.length() > 0) {
+                            cookies.append("; ");
+                        }
+                        cookies.append(value);
+                    } else {
+                        output.add(name, value);
+                    }
+                }
+            }
+            if (cookies != null) {
+                output.add(COOKIE, cookies.toString());
+            }
+        }
+    }
+
+    private static Http3Exception streamError(long streamId, Http3ErrorCode error, String msg, Throwable cause) {
+        return new Http3Exception(error, streamId + ": " + msg, cause);
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicStreamChannel.java
+++ b/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicStreamChannel.java
@@ -26,6 +26,8 @@ import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.channel.socket.ChannelInputShutdownEvent;
+import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.incubator.codec.quic.QuicChannel;
 import io.netty.incubator.codec.quic.QuicStreamAddress;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
@@ -57,6 +59,14 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
         this.localCreated = localCreated;
         this.type = type;
         this.id = id;
+    }
+
+    boolean writeInboundWithFin(Object... msgs) {
+        shutdownInput();
+        boolean written = writeInbound(msgs);
+        pipeline().fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
+        pipeline().fireUserEventTriggered(ChannelInputShutdownReadComplete.INSTANCE);
+        return written;
     }
 
     @Override

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
@@ -1,0 +1,725 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.incubator.codec.http3;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.EncoderException;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpScheme;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
+
+import io.netty.util.CharsetUtil;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Http3FrameToHttpObjectCodecTest {
+
+    @Test
+    public void testUpgradeEmptyFullResponse() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        assertTrue(ch.writeOutbound(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)));
+
+        Http3HeadersFrame headersFrame = ch.readOutbound();
+        assertThat(headersFrame.headers().status().toString(), is("200"));
+        assertTrue(ch.isOutputShutdown());
+
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void encode100ContinueAsHttp2HeadersFrameThatIsNotEndStream() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        assertTrue(ch.writeOutbound(new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE)));
+
+        Http3HeadersFrame headersFrame = ch.readOutbound();
+        assertThat(headersFrame.headers().status().toString(), is("100"));
+        assertFalse(ch.isOutputShutdown());
+
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test (expected = EncoderException.class)
+    public void encodeNonFullHttpResponse100ContinueIsRejected() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        try {
+            ch.writeOutbound(new DefaultHttpResponse(
+                    HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE));
+        } finally {
+            ch.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    public void testUpgradeNonEmptyFullResponse() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
+        assertTrue(ch.writeOutbound(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, hello)));
+
+        Http3HeadersFrame headersFrame = ch.readOutbound();
+        assertThat(headersFrame.headers().status().toString(), is("200"));
+
+        Http3DataFrame dataFrame = ch.readOutbound();
+        try {
+            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+        } finally {
+            dataFrame.release();
+        }
+
+        assertTrue(ch.isOutputShutdown());
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testUpgradeEmptyFullResponseWithTrailers() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        HttpHeaders trailers = response.trailingHeaders();
+        trailers.set("key", "value");
+        assertTrue(ch.writeOutbound(response));
+
+        Http3HeadersFrame headersFrame = ch.readOutbound();
+        assertThat(headersFrame.headers().status().toString(), is("200"));
+
+        Http3HeadersFrame trailersFrame = ch.readOutbound();
+        assertThat(trailersFrame.headers().get("key").toString(), is("value"));
+        assertTrue(ch.isOutputShutdown());
+
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testUpgradeNonEmptyFullResponseWithTrailers() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
+        FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, hello);
+        HttpHeaders trailers = response.trailingHeaders();
+        trailers.set("key", "value");
+        assertTrue(ch.writeOutbound(response));
+
+        Http3HeadersFrame headersFrame = ch.readOutbound();
+        assertThat(headersFrame.headers().status().toString(), is("200"));
+
+        Http3DataFrame dataFrame = ch.readOutbound();
+        try {
+            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+        } finally {
+            dataFrame.release();
+        }
+
+        Http3HeadersFrame trailersFrame = ch.readOutbound();
+        assertThat(trailersFrame.headers().get("key").toString(), is("value"));
+        assertTrue(ch.isOutputShutdown());
+
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testUpgradeHeaders() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        assertTrue(ch.writeOutbound(response));
+
+        Http3HeadersFrame headersFrame = ch.readOutbound();
+        assertThat(headersFrame.headers().status().toString(), is("200"));
+        assertFalse(ch.isOutputShutdown());
+
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testUpgradeChunk() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
+        HttpContent content = new DefaultHttpContent(hello);
+        assertTrue(ch.writeOutbound(content));
+
+        Http3DataFrame dataFrame = ch.readOutbound();
+        try {
+            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertFalse(ch.isOutputShutdown());
+        } finally {
+            dataFrame.release();
+        }
+
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testUpgradeEmptyEnd() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        LastHttpContent end = LastHttpContent.EMPTY_LAST_CONTENT;
+        assertTrue(ch.writeOutbound(end));
+
+        Http3HeadersFrame emptyFrame = ch.readOutbound();
+        assertTrue(emptyFrame.headers().isEmpty());
+
+        assertTrue(ch.isOutputShutdown());
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testUpgradeDataEnd() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
+        LastHttpContent end = new DefaultLastHttpContent(hello, true);
+        assertTrue(ch.writeOutbound(end));
+
+        Http3DataFrame dataFrame = ch.readOutbound();
+        try {
+            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+        } finally {
+            dataFrame.release();
+        }
+
+        assertTrue(ch.isOutputShutdown());
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testUpgradeDataEndWithTrailers() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
+        LastHttpContent trailers = new DefaultLastHttpContent(hello, true);
+        HttpHeaders headers = trailers.trailingHeaders();
+        headers.set("key", "value");
+        assertTrue(ch.writeOutbound(trailers));
+
+        Http3DataFrame dataFrame = ch.readOutbound();
+        try {
+            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+        } finally {
+            dataFrame.release();
+        }
+
+        Http3HeadersFrame headerFrame = ch.readOutbound();
+        assertThat(headerFrame.headers().get("key").toString(), is("value"));
+        assertTrue(ch.isOutputShutdown());
+
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testDowngradeHeaders() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        Http3Headers headers = new DefaultHttp3Headers();
+        headers.path("/");
+        headers.method("GET");
+
+        assertTrue(ch.writeInbound(new DefaultHttp3HeadersFrame(headers)));
+
+        HttpRequest request = ch.readInbound();
+        assertThat(request.uri(), is("/"));
+        assertThat(request.method(), is(HttpMethod.GET));
+        assertThat(request.protocolVersion(), is(HttpVersion.HTTP_1_1));
+        assertFalse(request instanceof FullHttpRequest);
+        assertTrue(HttpUtil.isTransferEncodingChunked(request));
+
+        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testDowngradeHeadersWithContentLength() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        Http3Headers headers = new DefaultHttp3Headers();
+        headers.path("/");
+        headers.method("GET");
+        headers.setInt("content-length", 0);
+
+        assertTrue(ch.writeInbound(new DefaultHttp3HeadersFrame(headers)));
+
+        HttpRequest request = ch.readInbound();
+        assertThat(request.uri(), is("/"));
+        assertThat(request.method(), is(HttpMethod.GET));
+        assertThat(request.protocolVersion(), is(HttpVersion.HTTP_1_1));
+        assertFalse(request instanceof FullHttpRequest);
+        assertFalse(HttpUtil.isTransferEncodingChunked(request));
+
+        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testDowngradeFullHeaders() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        Http3Headers headers = new DefaultHttp3Headers();
+        headers.path("/");
+        headers.method("GET");
+
+        assertTrue(ch.writeInboundWithFin(new DefaultHttp3HeadersFrame(headers)));
+
+        FullHttpRequest request = ch.readInbound();
+        try {
+            assertThat(request.uri(), is("/"));
+            assertThat(request.method(), is(HttpMethod.GET));
+            assertThat(request.protocolVersion(), is(HttpVersion.HTTP_1_1));
+            assertThat(request.content().readableBytes(), is(0));
+            assertTrue(request.trailingHeaders().isEmpty());
+            assertFalse(HttpUtil.isTransferEncodingChunked(request));
+        } finally {
+            request.release();
+        }
+
+        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testDowngradeTrailers() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        Http3Headers headers = new DefaultHttp3Headers();
+        headers.set("key", "value");
+
+        assertTrue(ch.writeInboundWithFin(new DefaultHttp3HeadersFrame(headers)));
+
+        LastHttpContent trailers = ch.readInbound();
+        try {
+            assertThat(trailers.content().readableBytes(), is(0));
+            assertThat(trailers.trailingHeaders().get("key"), is("value"));
+            assertFalse(trailers instanceof FullHttpRequest);
+        } finally {
+            trailers.release();
+        }
+
+        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testDowngradeData() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
+        assertTrue(ch.writeInbound(new DefaultHttp3DataFrame(hello)));
+
+        HttpContent content = ch.readInbound();
+        try {
+            assertThat(content.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertFalse(content instanceof LastHttpContent);
+        } finally {
+            content.release();
+        }
+
+        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testDowngradeEndData() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
+        ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
+        assertTrue(ch.writeInboundWithFin(new DefaultHttp3DataFrame(hello)));
+
+        LastHttpContent content = ch.readInbound();
+        try {
+            assertThat(content.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertTrue(content.trailingHeaders().isEmpty());
+        } finally {
+            content.release();
+        }
+
+        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    // client-specific tests
+    @Test
+    public void testEncodeEmptyFullRequest() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        assertTrue(ch.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world")));
+
+        Http3HeadersFrame headersFrame = ch.readOutbound();
+        Http3Headers headers = headersFrame.headers();
+
+        assertThat(headers.scheme().toString(), is("https"));
+        assertThat(headers.method().toString(), is("GET"));
+        assertThat(headers.path().toString(), is("/hello/world"));
+        assertTrue(ch.isOutputShutdown());
+
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testEncodeNonEmptyFullRequest() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
+        assertTrue(ch.writeOutbound(new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.PUT, "/hello/world", hello)));
+
+        Http3HeadersFrame headersFrame = ch.readOutbound();
+        Http3Headers headers = headersFrame.headers();
+
+        assertThat(headers.scheme().toString(), is("https"));
+        assertThat(headers.method().toString(), is("PUT"));
+        assertThat(headers.path().toString(), is("/hello/world"));
+
+        Http3DataFrame dataFrame = ch.readOutbound();
+        try {
+            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+        } finally {
+            dataFrame.release();
+        }
+
+        assertTrue(ch.isOutputShutdown());
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testEncodeEmptyFullRequestWithTrailers() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        FullHttpRequest request = new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.PUT, "/hello/world");
+
+        HttpHeaders trailers = request.trailingHeaders();
+        trailers.set("key", "value");
+        assertTrue(ch.writeOutbound(request));
+
+        Http3HeadersFrame headersFrame = ch.readOutbound();
+        Http3Headers headers = headersFrame.headers();
+
+        assertThat(headers.scheme().toString(), is("https"));
+        assertThat(headers.method().toString(), is("PUT"));
+        assertThat(headers.path().toString(), is("/hello/world"));
+
+        Http3HeadersFrame trailersFrame = ch.readOutbound();
+        assertThat(trailersFrame.headers().get("key").toString(), is("value"));
+
+        assertTrue(ch.isOutputShutdown());
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testEncodeNonEmptyFullRequestWithTrailers() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
+        FullHttpRequest request = new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.PUT, "/hello/world", hello);
+
+        HttpHeaders trailers = request.trailingHeaders();
+        trailers.set("key", "value");
+        assertTrue(ch.writeOutbound(request));
+
+        Http3HeadersFrame headersFrame = ch.readOutbound();
+        Http3Headers headers = headersFrame.headers();
+
+        assertThat(headers.scheme().toString(), is("https"));
+        assertThat(headers.method().toString(), is("PUT"));
+        assertThat(headers.path().toString(), is("/hello/world"));
+
+        Http3DataFrame dataFrame = ch.readOutbound();
+        try {
+            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+        } finally {
+            dataFrame.release();
+        }
+
+        Http3HeadersFrame trailersFrame = ch.readOutbound();
+        assertThat(trailersFrame.headers().get("key").toString(), is("value"));
+
+        assertTrue(ch.isOutputShutdown());
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testEncodeRequestHeaders() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world");
+        assertTrue(ch.writeOutbound(request));
+
+        Http3HeadersFrame headersFrame = ch.readOutbound();
+        Http3Headers headers = headersFrame.headers();
+
+        assertThat(headers.scheme().toString(), is("https"));
+        assertThat(headers.method().toString(), is("GET"));
+        assertThat(headers.path().toString(), is("/hello/world"));
+        assertFalse(ch.isOutputShutdown());
+
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testEncodeChunkAsClient() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
+        HttpContent content = new DefaultHttpContent(hello);
+        assertTrue(ch.writeOutbound(content));
+
+        Http3DataFrame dataFrame = ch.readOutbound();
+        try {
+            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+        } finally {
+            dataFrame.release();
+        }
+        assertFalse(ch.isOutputShutdown());
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testEncodeEmptyEndAsClient() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        LastHttpContent end = LastHttpContent.EMPTY_LAST_CONTENT;
+        assertTrue(ch.writeOutbound(end));
+
+        Http3HeadersFrame emptyFrame = ch.readOutbound();
+        assertTrue(emptyFrame.headers().isEmpty());
+
+        assertTrue(ch.isOutputShutdown());
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testEncodeDataEndAsClient() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
+        LastHttpContent end = new DefaultLastHttpContent(hello, true);
+        assertTrue(ch.writeOutbound(end));
+
+        Http3DataFrame dataFrame = ch.readOutbound();
+        try {
+            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+        } finally {
+            dataFrame.release();
+        }
+
+        assertTrue(ch.isOutputShutdown());
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testEncodeTrailersAsClient() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        LastHttpContent trailers = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER, true);
+        HttpHeaders headers = trailers.trailingHeaders();
+        headers.set("key", "value");
+        assertTrue(ch.writeOutbound(trailers));
+
+        Http3HeadersFrame headerFrame = ch.readOutbound();
+        assertThat(headerFrame.headers().get("key").toString(), is("value"));
+
+        assertTrue(ch.isOutputShutdown());
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testEncodeDataEndWithTrailersAsClient() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
+        LastHttpContent trailers = new DefaultLastHttpContent(hello, true);
+        HttpHeaders headers = trailers.trailingHeaders();
+        headers.set("key", "value");
+        assertTrue(ch.writeOutbound(trailers));
+
+        Http3DataFrame dataFrame = ch.readOutbound();
+        try {
+            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+        } finally {
+            dataFrame.release();
+        }
+
+        Http3HeadersFrame headerFrame = ch.readOutbound();
+        assertThat(headerFrame.headers().get("key").toString(), is("value"));
+
+        assertTrue(ch.isOutputShutdown());
+        assertThat(ch.readOutbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void decode100ContinueHttp2HeadersAsFullHttpResponse() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        Http3Headers headers = new DefaultHttp3Headers();
+        headers.scheme(HttpScheme.HTTP.name());
+        headers.status(HttpResponseStatus.CONTINUE.codeAsText());
+
+        assertTrue(ch.writeInbound(new DefaultHttp3HeadersFrame(headers)));
+
+        final FullHttpResponse response = ch.readInbound();
+        try {
+            assertThat(response.status(), is(HttpResponseStatus.CONTINUE));
+            assertThat(response.protocolVersion(), is(HttpVersion.HTTP_1_1));
+        } finally {
+            response.release();
+        }
+
+        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testDecodeResponseHeaders() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        Http3Headers headers = new DefaultHttp3Headers();
+        headers.scheme(HttpScheme.HTTP.name());
+        headers.status(HttpResponseStatus.OK.codeAsText());
+
+        assertTrue(ch.writeInbound(new DefaultHttp3HeadersFrame(headers)));
+
+        HttpResponse response = ch.readInbound();
+        assertThat(response.status(), is(HttpResponseStatus.OK));
+        assertThat(response.protocolVersion(), is(HttpVersion.HTTP_1_1));
+        assertFalse(response instanceof FullHttpResponse);
+        assertTrue(HttpUtil.isTransferEncodingChunked(response));
+
+        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testDecodeResponseHeadersWithContentLength() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        Http3Headers headers = new DefaultHttp3Headers();
+        headers.scheme(HttpScheme.HTTP.name());
+        headers.status(HttpResponseStatus.OK.codeAsText());
+        headers.setInt("content-length", 0);
+
+        assertTrue(ch.writeInbound(new DefaultHttp3HeadersFrame(headers)));
+
+        HttpResponse response = ch.readInbound();
+        assertThat(response.status(), is(HttpResponseStatus.OK));
+        assertThat(response.protocolVersion(), is(HttpVersion.HTTP_1_1));
+        assertFalse(response instanceof FullHttpResponse);
+        assertFalse(HttpUtil.isTransferEncodingChunked(response));
+
+        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testDecodeFullResponseHeaders() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        Http3Headers headers = new DefaultHttp3Headers();
+        headers.scheme(HttpScheme.HTTP.name());
+        headers.status(HttpResponseStatus.OK.codeAsText());
+
+        Http3HeadersFrame frame = new DefaultHttp3HeadersFrame(headers);
+
+        assertTrue(ch.writeInboundWithFin(frame));
+
+        FullHttpResponse response = ch.readInbound();
+        try {
+            assertThat(response.status(), is(HttpResponseStatus.OK));
+            assertThat(response.protocolVersion(), is(HttpVersion.HTTP_1_1));
+            assertThat(response.content().readableBytes(), is(0));
+            assertTrue(response.trailingHeaders().isEmpty());
+            assertFalse(HttpUtil.isTransferEncodingChunked(response));
+            assertEquals(0,
+                    (int) response.headers().getInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text()));
+        } finally {
+            response.release();
+        }
+
+        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testDecodeResponseTrailersAsClient() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        Http3Headers headers = new DefaultHttp3Headers();
+        headers.set("key", "value");
+        assertTrue(ch.writeInboundWithFin(new DefaultHttp3HeadersFrame(headers)));
+
+        LastHttpContent trailers = ch.readInbound();
+        try {
+            assertThat(trailers.content().readableBytes(), is(0));
+            assertThat(trailers.trailingHeaders().get("key"), is("value"));
+            assertFalse(trailers instanceof FullHttpRequest);
+        } finally {
+            trailers.release();
+        }
+
+        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testDecodeDataAsClient() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
+        assertTrue(ch.writeInbound(new DefaultHttp3DataFrame(hello)));
+
+        HttpContent content = ch.readInbound();
+        try {
+            assertThat(content.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertFalse(content instanceof LastHttpContent);
+        } finally {
+            content.release();
+        }
+
+        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testDecodeEndDataAsClient() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
+        assertTrue(ch.writeInboundWithFin(new DefaultHttp3DataFrame(hello)));
+
+        LastHttpContent content = ch.readInbound();
+        try {
+            assertThat(content.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertTrue(content.trailingHeaders().isEmpty());
+        } finally {
+            content.release();
+        }
+
+        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/HttpConversionUtilTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/HttpConversionUtilTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.AsciiString;
+import org.junit.Test;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.COOKIE;
+import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
+import static io.netty.handler.codec.http.HttpHeaderNames.KEEP_ALIVE;
+import static io.netty.handler.codec.http.HttpHeaderNames.PROXY_CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.TE;
+import static io.netty.handler.codec.http.HttpHeaderNames.TRANSFER_ENCODING;
+import static io.netty.handler.codec.http.HttpHeaderNames.UPGRADE;
+import static io.netty.handler.codec.http.HttpHeaderValues.GZIP;
+import static io.netty.handler.codec.http.HttpHeaderValues.TRAILERS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class HttpConversionUtilTest {
+    @Test
+    public void setHttp3AuthorityWithoutUserInfo() {
+        Http3Headers headers = new DefaultHttp3Headers();
+
+        HttpConversionUtil.setHttp3Authority("foo", headers);
+        assertEquals(new AsciiString("foo"), headers.authority());
+    }
+
+    @Test
+    public void setHttp3AuthorityWithUserInfo() {
+        Http3Headers headers = new DefaultHttp3Headers();
+
+        HttpConversionUtil.setHttp3Authority("info@foo", headers);
+        assertEquals(new AsciiString("foo"), headers.authority());
+
+        HttpConversionUtil.setHttp3Authority("@foo.bar", headers);
+        assertEquals(new AsciiString("foo.bar"), headers.authority());
+    }
+
+    @Test
+    public void setHttp3AuthorityNullOrEmpty() {
+        Http3Headers headers = new DefaultHttp3Headers();
+
+        HttpConversionUtil.setHttp3Authority(null, headers);
+        assertNull(headers.authority());
+
+        HttpConversionUtil.setHttp3Authority("", headers);
+        assertSame(AsciiString.EMPTY_STRING, headers.authority());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setHttp2AuthorityWithEmptyAuthority() {
+        HttpConversionUtil.setHttp3Authority("info@", new DefaultHttp3Headers());
+    }
+
+    @Test
+    public void stripTEHeaders() {
+        HttpHeaders inHeaders = new DefaultHttpHeaders();
+        inHeaders.add(TE, GZIP);
+        Http3Headers out = new DefaultHttp3Headers();
+        HttpConversionUtil.toHttp3Headers(inHeaders, out);
+        assertTrue(out.isEmpty());
+    }
+
+    @Test
+    public void stripTEHeadersExcludingTrailers() {
+        HttpHeaders inHeaders = new DefaultHttpHeaders();
+        inHeaders.add(TE, GZIP);
+        inHeaders.add(TE, TRAILERS);
+        Http3Headers out = new DefaultHttp3Headers();
+        HttpConversionUtil.toHttp3Headers(inHeaders, out);
+        assertSame(TRAILERS, out.get(TE));
+    }
+
+    @Test
+    public void stripTEHeadersCsvSeparatedExcludingTrailers() {
+        HttpHeaders inHeaders = new DefaultHttpHeaders();
+        inHeaders.add(TE, GZIP + "," + TRAILERS);
+        Http3Headers out = new DefaultHttp3Headers();
+        HttpConversionUtil.toHttp3Headers(inHeaders, out);
+        assertSame(TRAILERS, out.get(TE));
+    }
+
+    @Test
+    public void stripTEHeadersCsvSeparatedAccountsForValueSimilarToTrailers() {
+        HttpHeaders inHeaders = new DefaultHttpHeaders();
+        inHeaders.add(TE, GZIP + "," + TRAILERS + "foo");
+        Http3Headers out = new DefaultHttp3Headers();
+        HttpConversionUtil.toHttp3Headers(inHeaders, out);
+        assertFalse(out.contains(TE));
+    }
+
+    @Test
+    public void stripTEHeadersAccountsForValueSimilarToTrailers() {
+        HttpHeaders inHeaders = new DefaultHttpHeaders();
+        inHeaders.add(TE, TRAILERS + "foo");
+        Http3Headers out = new DefaultHttp3Headers();
+        HttpConversionUtil.toHttp3Headers(inHeaders, out);
+        assertFalse(out.contains(TE));
+    }
+
+    @Test
+    public void stripTEHeadersAccountsForOWS() {
+        HttpHeaders inHeaders = new DefaultHttpHeaders();
+        inHeaders.add(TE, " " + TRAILERS + " ");
+        Http3Headers out = new DefaultHttp3Headers();
+        HttpConversionUtil.toHttp3Headers(inHeaders, out);
+        assertSame(TRAILERS, out.get(TE));
+    }
+
+    @Test
+    public void stripConnectionHeadersAndNominees() {
+        HttpHeaders inHeaders = new DefaultHttpHeaders();
+        inHeaders.add(CONNECTION, "foo");
+        inHeaders.add("foo", "bar");
+        Http3Headers out = new DefaultHttp3Headers();
+        HttpConversionUtil.toHttp3Headers(inHeaders, out);
+        assertTrue(out.isEmpty());
+    }
+
+    @Test
+    public void stripConnectionNomineesWithCsv() {
+        HttpHeaders inHeaders = new DefaultHttpHeaders();
+        inHeaders.add(CONNECTION, "foo,  bar");
+        inHeaders.add("foo", "baz");
+        inHeaders.add("bar", "qux");
+        inHeaders.add("hello", "world");
+        Http3Headers out = new DefaultHttp3Headers();
+        HttpConversionUtil.toHttp3Headers(inHeaders, out);
+        assertEquals(1, out.size());
+        assertSame("world", out.get("hello"));
+    }
+
+    @Test
+    public void addHttp3ToHttpHeadersCombinesCookies() throws Http3Exception {
+        Http3Headers inHeaders = new DefaultHttp3Headers();
+        inHeaders.add("yes", "no");
+        inHeaders.add(COOKIE, "foo=bar");
+        inHeaders.add(COOKIE, "bax=baz");
+
+        HttpHeaders outHeaders = new DefaultHttpHeaders();
+
+        HttpConversionUtil.addHttp3ToHttpHeaders(5, inHeaders, outHeaders, HttpVersion.HTTP_1_1, false, false);
+        assertEquals("no", outHeaders.get("yes"));
+        assertEquals("foo=bar; bax=baz", outHeaders.get(COOKIE.toString()));
+    }
+
+    @Test
+    public void connectionSpecificHeadersShouldBeRemoved() {
+        HttpHeaders inHeaders = new DefaultHttpHeaders();
+        inHeaders.add(CONNECTION, "keep-alive");
+        inHeaders.add(HOST, "example.com");
+        @SuppressWarnings("deprecation")
+        AsciiString keepAlive = KEEP_ALIVE;
+        inHeaders.add(keepAlive, "timeout=5, max=1000");
+        @SuppressWarnings("deprecation")
+        AsciiString proxyConnection = PROXY_CONNECTION;
+        inHeaders.add(proxyConnection, "timeout=5, max=1000");
+        inHeaders.add(TRANSFER_ENCODING, "chunked");
+        inHeaders.add(UPGRADE, "h2c");
+
+        Http3Headers outHeaders = new DefaultHttp3Headers();
+        HttpConversionUtil.toHttp3Headers(inHeaders, outHeaders);
+
+        assertFalse(outHeaders.contains(CONNECTION));
+        assertFalse(outHeaders.contains(HOST));
+        assertFalse(outHeaders.contains(keepAlive));
+        assertFalse(outHeaders.contains(proxyConnection));
+        assertFalse(outHeaders.contains(TRANSFER_ENCODING));
+        assertFalse(outHeaders.contains(UPGRADE));
+    }
+
+    @Test
+    public void http3ToHttpHeaderTest() throws Exception {
+        Http3Headers http3Headers = new DefaultHttp3Headers();
+        http3Headers.status("200");
+        http3Headers.path("/meow"); // HTTP/2 Header response should not contain 'path' in response.
+        http3Headers.set("cat", "meow");
+
+        HttpHeaders httpHeaders = new DefaultHttpHeaders();
+        HttpConversionUtil.addHttp3ToHttpHeaders(3, http3Headers, httpHeaders, HttpVersion.HTTP_1_1, false, true);
+        assertFalse(httpHeaders.contains(HttpConversionUtil.ExtensionHeaderNames.PATH.text()));
+        assertEquals("meow", httpHeaders.get("cat"));
+
+        httpHeaders.clear();
+        HttpConversionUtil.addHttp3ToHttpHeaders(3, http3Headers, httpHeaders, HttpVersion.HTTP_1_1, false, false);
+        assertTrue(httpHeaders.contains(HttpConversionUtil.ExtensionHeaderNames.PATH.text()));
+        assertEquals("meow", httpHeaders.get("cat"));
+    }
+}


### PR DESCRIPTION
Motivation:

Often people not really care about the details of HTTP/3 but just want to be able to reuse their existing code that they use for HTTP/1.1. We can make this easier by providing a handler which does the convertion just as we do in HTTP/2.

Modifications:

- Port over code from netty for Http3FrameToHttpObjectCodec
- Add unit tests

Result:

Easier to use HTTP3 for existing code-bases