### PR TITLE
Don't wrap buffers when encoding data frames

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameCodec.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameCodec.java
@@ -343,11 +343,11 @@ final class Http3FrameCodec extends ByteToMessageDecoder implements ChannelOutbo
 
     private static void writeDataFrame(
             ChannelHandlerContext ctx, Http3DataFrame frame, ChannelPromise promise) {
-        ByteBuf out = ctx.alloc().directBuffer();
+        ByteBuf out = ctx.alloc().directBuffer(16);
         writeVariableLengthInteger(out, frame.type());
         writeVariableLengthInteger(out, frame.content().readableBytes());
-        ByteBuf content = frame.content().retain();
-        ctx.write(Unpooled.wrappedUnmodifiableBuffer(out, content), promise);
+        ctx.write(out);
+        ctx.write(frame.content().retain(), promise);
     }
 
     private void writeHeadersFrame(


### PR DESCRIPTION
Motivation:

Our QUIC implementation better handles non composite buffers in terms of performance.

Modifications:

Just write the buffer directly

Result:

A bit better performance