### PR TITLE
Don't allow duplicates for pseudo headers

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3HeadersSink.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3HeadersSink.java
@@ -63,7 +63,7 @@ final class Http3HeadersSink implements BiConsumer<CharSequence, CharSequence> {
 
         if (validate) {
             try {
-                previousType = validate(name, previousType);
+                previousType = validate(headers, name, previousType);
             } catch (Http3HeadersValidationException ex) {
                 validationException = ex;
                 return;
@@ -73,7 +73,7 @@ final class Http3HeadersSink implements BiConsumer<CharSequence, CharSequence> {
         headers.add(name, value);
     }
 
-    private static HeaderType validate(CharSequence name, HeaderType previousHeaderType) {
+    private static HeaderType validate(Http3Headers headers, CharSequence name, HeaderType previousHeaderType) {
         if (hasPseudoHeaderFormat(name)) {
             if (previousHeaderType == HeaderType.REGULAR_HEADER) {
                 throw new Http3HeadersValidationException(
@@ -92,6 +92,11 @@ final class Http3HeadersSink implements BiConsumer<CharSequence, CharSequence> {
                 throw new Http3HeadersValidationException("Mix of request and response pseudo-headers.");
             }
 
+            if (headers.contains(name)) {
+                // There can't be any duplicates for pseudy header names.
+                throw new Http3HeadersValidationException(
+                        String.format("Pseudo-header field '%s' exists already.", name));
+            }
             return currentHeaderType;
         }
 

--- a/src/test/java/io/netty/incubator/codec/http3/Http3HeadersSinkTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3HeadersSinkTest.java
@@ -74,4 +74,13 @@ public class Http3HeadersSinkTest {
         sink.finish();
         Assert.assertEquals("value", headers.get(Http3Headers.PseudoHeaderName.AUTHORITY.value()));
     }
+
+    @Test(expected = Http3HeadersValidationException.class)
+    public void testDuplicatePseudoHeader() throws Http3Exception {
+        Http3HeadersSink sink = new Http3HeadersSink(new DefaultHttp3Headers(), 512, true);
+        sink.accept(Http3Headers.PseudoHeaderName.AUTHORITY.value(), "value");
+        sink.accept(Http3Headers.PseudoHeaderName.AUTHORITY.value(), "value");
+        sink.finish();
+    }
+
 }


### PR DESCRIPTION
Motivation:

Pseudo headers should be only included once as per spec

Modifications:

Add validation for pseudo-headers and so enforce no duplicates are included

Result:

Follow more closely the spec