### PR TITLE
Correctly handle missing settings frame in all cases

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamInboundHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamInboundHandler.java
@@ -54,6 +54,17 @@ final class Http3ControlStreamInboundHandler extends Http3FrameTypeValidationHan
     }
 
     @Override
+    void frameTypeUnexpected(ChannelHandlerContext ctx, Object frame) {
+        if (!firstFrameRead && !(frame instanceof Http3SettingsFrame)) {
+            Http3CodecUtils.connectionError(ctx, Http3ErrorCode.H3_MISSING_SETTINGS,
+                    "Missing settings frame.", forwardControlFrames());
+            ReferenceCountUtil.release(frame);
+            return;
+        }
+        super.frameTypeUnexpected(ctx, frame);
+    }
+
+    @Override
     public void channelRead(ChannelHandlerContext ctx, Http3ControlStreamFrame frame) {
         final boolean firstFrame;
         if (!firstFrameRead) {

--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandler.java
@@ -72,7 +72,7 @@ class Http3FrameTypeValidationHandler<T extends Http3Frame> extends ChannelDuple
                 "Frame of type " + type + " unexpected"));
     }
 
-    static void frameTypeUnexpected(ChannelHandlerContext ctx, Object frame) {
+    void frameTypeUnexpected(ChannelHandlerContext ctx, Object frame) {
         ReferenceCountUtil.release(frame);
         Http3CodecUtils.connectionError(ctx, Http3ErrorCode.H3_FRAME_UNEXPECTED, "Frame type unexpected", true);
     }

--- a/src/test/java/io/netty/incubator/codec/http3/AbstractHttp3FrameTypeValidationHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/AbstractHttp3FrameTypeValidationHandlerTest.java
@@ -69,18 +69,23 @@ public abstract class AbstractHttp3FrameTypeValidationHandlerTest<T extends Http
         QuicChannel parent = mockParent();
         EmbeddedChannel channel = newChannel(parent, newHandler());
 
+        Http3ErrorCode errorCode = inboundErrorCodeInvalid();
         List<Http3Frame> invalidFrames = newInvalidFrames();
         for (Http3Frame invalid : invalidFrames) {
             try {
                 channel.writeInbound(invalid);
                 fail();
             } catch (Exception e) {
-                assertException(Http3ErrorCode.H3_FRAME_UNEXPECTED, e);
+                assertException(errorCode, e);
             }
             assertFrameReleased(invalid);
         }
-        verifyClose(invalidFrames.size(), Http3ErrorCode.H3_FRAME_UNEXPECTED, parent);
+        verifyClose(invalidFrames.size(), errorCode, parent);
         assertFalse(channel.finish());
+    }
+
+    protected Http3ErrorCode inboundErrorCodeInvalid() {
+        return Http3ErrorCode.H3_FRAME_UNEXPECTED;
     }
 
     @Test


### PR DESCRIPTION
Motivation:

We didn't correctly handle the case if a frame on the control stream was the first frame and not a settings frame. We always need to handle this as H3_MISSING_SETTINGS

Modifications:

- Correctly handle missing settings frame
- Adjust unit test

Result:

Correctly follow spec