### PR TITLE
Shutdown the stream with an error when an invalid message was detected

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
   <properties>
     <javaModuleName>io.netty.incubator.codec.http3</javaModuleName>
     <skipTests>false</skipTests>
-    <netty.version>4.1.59.Final</netty.version>
+    <netty.version>4.1.60.Final</netty.version>
     <netty.build.version>28</netty.build.version>
     <netty.quic.version>0.0.8.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>

--- a/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
@@ -20,6 +20,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.ObjectUtil;
 
@@ -248,6 +249,10 @@ final class Http3CodecUtils {
             buffer = Unpooled.EMPTY_BUFFER;
         }
         quicChannel.close(true, errorCode.code, buffer);
+    }
+
+    static void streamError(ChannelHandlerContext ctx, Http3ErrorCode errorCode) {
+        ((QuicStreamChannel) ctx.channel()).shutdownOutput(errorCode.code);
     }
 
     static void readIfNoAutoRead(ChannelHandlerContext ctx) {

--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameCodec.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameCodec.java
@@ -306,9 +306,9 @@ final class Http3FrameCodec extends ByteToMessageDecoder implements ChannelOutbo
             return false;
         } catch (Http3HeadersValidationException e) {
             ctx.fireExceptionCaught(e);
-            // We should close the stream.
+            // We should shutdown the stream with an error.
             // See https://tools.ietf.org/html/draft-ietf-quic-http-32#section-4.1.3
-            ctx.close();
+            Http3CodecUtils.streamError(ctx, Http3ErrorCode.H3_MESSAGE_ERROR);
             return false;
         }
         return true;


### PR DESCRIPTION
Motivation:
We should shutdown the stream with an error if an error was detected and not jsut use a FIN.

Modification:
Make use of the new methods exposed by QuicStreamChannel which allows to shutdown the stream with an error.

Result:
More closely follow the spec