### PR TITLE
Verify that mandatory pseudo-headers are included

### DIFF
--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameCodecTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameCodecTest.java
@@ -338,6 +338,7 @@ public class Http3FrameCodecTest {
         headers.add(":authority", "netty.quic"); // name only
         headers.add(":path", "/"); // name & value
         headers.add(":method", "GET"); // name & value with few options per name
+        headers.add(":scheme", "https");
         headers.add("x-qpack-draft", "19");
     }
 


### PR DESCRIPTION
Motivation:

We should validate that all mandatory pseudo-headers are included

Modifications:

- Add validation for this case
- Add unit tests

Result:

Follow the spec more closely