### PR TITLE
Validate the frame type as soon as possible

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamFrameTypeValidator.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamFrameTypeValidator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+/**
+ * Validate that the frame type is valid for a control stream.
+ */
+final class Http3ControlStreamFrameTypeValidator implements Http3FrameTypeValidator {
+
+    static final Http3ControlStreamFrameTypeValidator INSTANCE = new Http3ControlStreamFrameTypeValidator();
+
+    private Http3ControlStreamFrameTypeValidator() { }
+
+    @Override
+    public void validate(long type, boolean first) throws Http3Exception {
+        switch ((int) type) {
+            case Http3CodecUtils.HTTP3_HEADERS_FRAME_TYPE:
+            case Http3CodecUtils.HTTP3_DATA_FRAME_TYPE:
+                if (first) {
+                    throw new Http3Exception(Http3ErrorCode.H3_MISSING_SETTINGS,
+                            "Missing settings frame.");
+                }
+                throw new Http3Exception(Http3ErrorCode.H3_FRAME_UNEXPECTED,
+                        "Unexpected frame type '" + type + "' received");
+            default:
+               break;
+        }
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameTypeValidator.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameTypeValidator.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+@FunctionalInterface
+interface Http3FrameTypeValidator {
+
+    Http3FrameTypeValidator NO_VALIDATION = (type, first) -> { };
+
+    void validate(long type, boolean first) throws Http3Exception;
+}

--- a/src/main/java/io/netty/incubator/codec/http3/Http3RequestStreamFrameTypeValidator.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3RequestStreamFrameTypeValidator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+/**
+ * Validate that the frame type is valid for a request stream.
+ */
+final class Http3RequestStreamFrameTypeValidator implements Http3FrameTypeValidator {
+
+    static final Http3RequestStreamFrameTypeValidator INSTANCE = new Http3RequestStreamFrameTypeValidator();
+
+    private Http3RequestStreamFrameTypeValidator() { }
+
+    @Override
+    public void validate(long type, boolean first) throws Http3Exception {
+        switch ((int) type) {
+            case Http3CodecUtils.HTTP3_CANCEL_PUSH_FRAME_TYPE:
+            case Http3CodecUtils.HTTP3_GO_AWAY_FRAME_TYPE:
+            case Http3CodecUtils.HTTP3_MAX_PUSH_ID_FRAME_TYPE:
+            case Http3CodecUtils.HTTP3_SETTINGS_FRAME_TYPE:
+                throw new Http3Exception(Http3ErrorCode.H3_FRAME_UNEXPECTED,
+                        "Unexpected frame type '" + type + "' received");
+            default:
+                break;
+        }
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameCodecTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameCodecTest.java
@@ -21,8 +21,6 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.DefaultChannelId;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.incubator.codec.quic.QuicChannel;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -502,7 +500,7 @@ public class Http3FrameCodecTest {
     }
 
     private static Http3FrameCodec newCodec() {
-        return new Http3FrameCodec(new QpackDecoder(), MAX_HEADER_SIZE,
+        return new Http3FrameCodec(Http3FrameTypeValidator.NO_VALIDATION, new QpackDecoder(), MAX_HEADER_SIZE,
                 new QpackEncoder());
     }
 }

--- a/src/test/java/io/netty/incubator/codec/http3/Http3UnidirectionalStreamInboundHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3UnidirectionalStreamInboundHandlerTest.java
@@ -154,7 +154,7 @@ public class Http3UnidirectionalStreamInboundHandlerTest {
         }
 
         Http3UnidirectionalStreamInboundHandler handler = new Http3UnidirectionalStreamInboundHandler(
-                CodecHandler::new, new Http3ControlStreamInboundHandler(server, null),
+                v -> new CodecHandler(), new Http3ControlStreamInboundHandler(server, null),
                 outboundControlHandler, null);
         EmbeddedChannel channel =  new EmbeddedChannel(parent, DefaultChannelId.newInstance(),
                 true, false, handler);
@@ -209,7 +209,7 @@ public class Http3UnidirectionalStreamInboundHandlerTest {
 
         channel = new EmbeddedChannel(channel.parent(), DefaultChannelId.newInstance(),
                 true, false, new Http3UnidirectionalStreamInboundHandler(
-                CodecHandler::new, new Http3ControlStreamInboundHandler(server, null),
+                v -> new CodecHandler(), new Http3ControlStreamInboundHandler(server, null),
                 new Http3ControlStreamOutboundHandler(server, new DefaultHttp3SettingsFrame(),
                         new CodecHandler()), null));
 
@@ -231,7 +231,7 @@ public class Http3UnidirectionalStreamInboundHandlerTest {
         AttributeMap map = new DefaultAttributeMap();
         when(parent.attr(any())).then(i -> map.attr(i.getArgument(0)));
         Http3UnidirectionalStreamInboundHandler handler = new Http3UnidirectionalStreamInboundHandler(
-                CodecHandler::new, new Http3ControlStreamInboundHandler(server, null),
+                v -> new CodecHandler(), new Http3ControlStreamInboundHandler(server, null),
                 new Http3ControlStreamOutboundHandler(server, new DefaultHttp3SettingsFrame(),
                         new CodecHandler()), factory);
         return new EmbeddedChannel(parent, DefaultChannelId.newInstance(),


### PR DESCRIPTION
Motivation:

We should validate the frame type as soon as possible so we fail with the correct error code

Modifications:

Move basic validation into the Http3FrameCodec

Result:

More correct implementation