### PR TITLE
Send H3_CLOSED_CRITICAL_STREAM to remote peer if the control stream w…

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamInboundHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamInboundHandler.java
@@ -17,6 +17,7 @@ package io.netty.incubator.codec.http3;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.util.ReferenceCountUtil;
 
 final class Http3ControlStreamInboundHandler extends Http3FrameTypeValidationHandler<Http3ControlStreamFrame> {
@@ -165,5 +166,14 @@ final class Http3ControlStreamInboundHandler extends Http3FrameTypeValidationHan
     public boolean isSharable() {
         // Not sharable as it keeps state.
         return false;
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        if (evt instanceof ChannelInputShutdownEvent) {
+            // See https://www.ietf.org/archive/id/draft-ietf-quic-qpack-19.html#section-4.2
+            Http3CodecUtils.criticalStreamClosed(ctx);
+        }
+        ctx.fireUserEventTriggered(evt);
     }
 }

--- a/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicStreamChannel.java
+++ b/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicStreamChannel.java
@@ -68,9 +68,18 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
     boolean writeInboundWithFin(Object... msgs) {
         shutdownInput();
         boolean written = writeInbound(msgs);
+        fireInputShutdownEvents();
+        return written;
+    }
+
+    void writeInboundFin() {
+        shutdownInput();
+        fireInputShutdownEvents();
+    }
+
+    private void fireInputShutdownEvents() {
         pipeline().fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
         pipeline().fireUserEventTriggered(ChannelInputShutdownReadComplete.INSTANCE);
-        return written;
     }
 
     @Override


### PR DESCRIPTION
…as closed

Motivation:

We need to fail the connection with H3_CLOSED_CRITICAL_STREAM if the control stream was closed

Modifications:

- Add code to handle the closure of a critical stream
- Add unit test

Result:

More compliant with the spec