### PR TITLE
Fix bounds check and so correctly produce QpackException when an inva…

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/QpackDecoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackDecoder.java
@@ -129,7 +129,7 @@ final class QpackDecoder {
     }
 
     private static CharSequence getIndexedName(int index) throws QpackException {
-        if (index <= QpackStaticTable.length) {
+        if (index < QpackStaticTable.length) {
             final QpackHeaderField field = QpackStaticTable.getField(index);
             return field.name;
         }
@@ -137,7 +137,7 @@ final class QpackDecoder {
     }
 
     private static QpackHeaderField getIndexedHeader(int index) throws QpackException {
-        if (index <= QpackStaticTable.length) {
+        if (index < QpackStaticTable.length) {
             return QpackStaticTable.getField(index);
         }
         throw HEADER_ILLEGAL_INDEX_VALUE;


### PR DESCRIPTION
…lid index is used

Motivation:

We had an "off-by-one" error in the bounds check which did result in IndexOutOfBoundsException when it should have been a QpackException.

Modifications:

Fix if branch

Result:

Correctly throw QpackException for invalid index