### PR TITLE
Also add the Http3FrameCodec to the pipeline of the push stream

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3PushStreamFrameTypeValidator.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3PushStreamFrameTypeValidator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+/**
+ * Validate that the frame type is valid for a push stream.
+ */
+final class Http3PushStreamFrameTypeValidator implements Http3FrameTypeValidator {
+
+    static final Http3PushStreamFrameTypeValidator INSTANCE = new Http3PushStreamFrameTypeValidator();
+
+    private Http3PushStreamFrameTypeValidator() { }
+
+    @Override
+    public void validate(long type, boolean first) throws Http3Exception {
+        switch ((int) type) {
+            case Http3CodecUtils.HTTP3_PUSH_PROMISE_FRAME_TYPE:
+            case Http3CodecUtils.HTTP3_CANCEL_PUSH_FRAME_TYPE:
+            case Http3CodecUtils.HTTP3_GO_AWAY_FRAME_TYPE:
+            case Http3CodecUtils.HTTP3_MAX_PUSH_ID_FRAME_TYPE:
+            case Http3CodecUtils.HTTP3_SETTINGS_FRAME_TYPE:
+                throw new Http3Exception(Http3ErrorCode.H3_FRAME_UNEXPECTED,
+                        "Unexpected frame type '" + type + "' received");
+            default:
+                break;
+        }
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/http3/Http3UnidirectionalStreamInboundHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3UnidirectionalStreamInboundHandler.java
@@ -137,11 +137,13 @@ final class Http3UnidirectionalStreamInboundHandler extends ByteToMessageDecoder
                         "Received push stream with id " + id + " while the max push id is " + maxPushId + '.', false);
             } else {
                 // TODO: Handle push streams correctly
+                ctx.pipeline().addLast(Http3PushStreamValidationHandler.INSTANCE);
                 // For now add a handler that will just release the frames so we dont leak.
                 ctx.pipeline().addLast(ReleaseHandler.INSTANCE);
 
-                // Replace this handler with a handler that validates the frames on the stream.
-                ctx.pipeline().replace(this, null, Http3PushStreamValidationHandler.INSTANCE);
+                // Replace this handler with the codec which also validates that only valid frames will be decoded.
+                ctx.pipeline().replace(this, null,
+                        codecFactory.apply(Http3PushStreamFrameTypeValidator.NO_VALIDATION));
             }
         }
     }


### PR DESCRIPTION
Motivation:

We did miss to also add the codec to the pipeline of a push stream

Modifications:

Add the codec and add a test

Result:

Correctly decode frames on a push stream