### PR TITLE
Correctly reject push promise frames on the control stream

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamFrameTypeValidator.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ControlStreamFrameTypeValidator.java
@@ -27,6 +27,7 @@ final class Http3ControlStreamFrameTypeValidator implements Http3FrameTypeValida
     @Override
     public void validate(long type, boolean first) throws Http3Exception {
         switch ((int) type) {
+            case Http3CodecUtils.HTTP3_PUSH_PROMISE_FRAME_TYPE:
             case Http3CodecUtils.HTTP3_HEADERS_FRAME_TYPE:
             case Http3CodecUtils.HTTP3_DATA_FRAME_TYPE:
                 if (first) {

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamFrameTypeValidatorTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamFrameTypeValidatorTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+public class Http3ControlStreamFrameTypeValidatorTest extends Http3FrameTypeValidatorTest {
+
+    @Override
+    protected long[] invalidFramesTypes() {
+        return new long[] {
+                Http3CodecUtils.HTTP3_DATA_FRAME_TYPE,
+                Http3CodecUtils.HTTP3_HEADERS_FRAME_TYPE,
+                Http3CodecUtils.HTTP3_PUSH_PROMISE_FRAME_TYPE
+        };
+    }
+
+    @Override
+    protected long[] validFrameTypes() {
+        return new long[] {
+                Http3CodecUtils.HTTP3_CANCEL_PUSH_FRAME_TYPE,
+                Http3CodecUtils.HTTP3_GO_AWAY_FRAME_TYPE,
+                Http3CodecUtils.HTTP3_MAX_PUSH_ID_FRAME_TYPE,
+                Http3CodecUtils.HTTP3_SETTINGS_FRAME_TYPE
+        };
+    }
+
+    @Override
+    protected Http3FrameTypeValidator newValidator() {
+        return Http3ControlStreamFrameTypeValidator.INSTANCE;
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameTypeValidatorTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameTypeValidatorTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public abstract class Http3FrameTypeValidatorTest {
+
+    protected abstract long[] invalidFramesTypes();
+    protected abstract long[] validFrameTypes();
+
+    protected abstract Http3FrameTypeValidator newValidator();
+
+    @Test
+    public void testValidFrameTypes() throws Exception {
+        for (long validFrameType: validFrameTypes()) {
+            newValidator().validate(validFrameType, true);
+        }
+    }
+
+    @Test
+    public void testInvalidFrameTypes() {
+        for (long invalidFrameType: invalidFramesTypes()) {
+            try {
+                newValidator().validate(invalidFrameType, true);
+                Assert.fail("Expected failure for frame type: " + invalidFrameType);
+            } catch (Http3Exception expected) {
+                // ignore
+            }
+        }
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/Http3PushStreamFrameTypeValidatorTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3PushStreamFrameTypeValidatorTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+public class Http3PushStreamFrameTypeValidatorTest extends Http3FrameTypeValidatorTest {
+
+    @Override
+    protected long[] invalidFramesTypes() {
+        return new long[] {
+                Http3CodecUtils.HTTP3_PUSH_PROMISE_FRAME_TYPE,
+                Http3CodecUtils.HTTP3_CANCEL_PUSH_FRAME_TYPE,
+                Http3CodecUtils.HTTP3_GO_AWAY_FRAME_TYPE,
+                Http3CodecUtils.HTTP3_MAX_PUSH_ID_FRAME_TYPE,
+                Http3CodecUtils.HTTP3_SETTINGS_FRAME_TYPE
+        };
+    }
+
+    @Override
+    protected long[] validFrameTypes() {
+        return new long[] {
+                Http3CodecUtils.HTTP3_DATA_FRAME_TYPE,
+                Http3CodecUtils.HTTP3_HEADERS_FRAME_TYPE
+        };
+    }
+
+    @Override
+    protected Http3FrameTypeValidator newValidator() {
+        return Http3PushStreamFrameTypeValidator.INSTANCE;
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamFrameTypeValidatorTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamFrameTypeValidatorTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+public class Http3RequestStreamFrameTypeValidatorTest extends Http3FrameTypeValidatorTest {
+
+    @Override
+    protected long[] invalidFramesTypes() {
+        return new long[] {
+                Http3CodecUtils.HTTP3_CANCEL_PUSH_FRAME_TYPE,
+                Http3CodecUtils.HTTP3_GO_AWAY_FRAME_TYPE,
+                Http3CodecUtils.HTTP3_MAX_PUSH_ID_FRAME_TYPE,
+                Http3CodecUtils.HTTP3_SETTINGS_FRAME_TYPE
+        };
+    }
+
+    @Override
+    protected long[] validFrameTypes() {
+        return new long[] {
+                Http3CodecUtils.HTTP3_DATA_FRAME_TYPE,
+                Http3CodecUtils.HTTP3_HEADERS_FRAME_TYPE,
+                Http3CodecUtils.HTTP3_PUSH_PROMISE_FRAME_TYPE
+        };
+    }
+
+    @Override
+    protected Http3FrameTypeValidator newValidator() {
+        return Http3RequestStreamFrameTypeValidator.INSTANCE;
+    }
+}


### PR DESCRIPTION
Motivation:

We also need to reject push promise frames on the control stream

Modifications:

- Correctly reject push promise frames as well
- Add unit tests for all frame type validators

Result:

Correctly reject push promise frames and more tests