### PR TITLE
Update netty-build version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <javaModuleName>io.netty.incubator.codec.http3</javaModuleName>
     <skipTests>false</skipTests>
     <netty.version>4.1.60.Final</netty.version>
-    <netty.build.version>28</netty.build.version>
+    <netty.build.version>29</netty.build.version>
     <netty.quic.version>0.0.8.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

We released a new version of netty-build

Modifications:

Update to latest version

Result:

Use latest netty-build version