### PR TITLE
Correctly validate and convert CONNECT requests

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/HttpConversionUtil.java
+++ b/src/main/java/io/netty/incubator/codec/http3/HttpConversionUtil.java
@@ -197,6 +197,15 @@ public final class HttpConversionUtil {
         return msg;
     }
 
+    private static String extractPath(CharSequence method, Http3Headers headers) {
+        if (HttpMethod.CONNECT.asciiName().contentEqualsIgnoreCase(method)) {
+            return "/";
+        } else {
+            return checkNotNull(headers.path(),
+                    "path header cannot be null in conversion to HTTP/1.x").toString();
+        }
+    }
+
     /**
      * Create a new object to contain the request data
      *
@@ -216,10 +225,9 @@ public final class HttpConversionUtil {
         // HTTP/3 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line.
         final CharSequence method = checkNotNull(http3Headers.method(),
                 "method header cannot be null in conversion to HTTP/1.x");
-        final CharSequence path = checkNotNull(http3Headers.path(),
-                "path header cannot be null in conversion to HTTP/1.x");
+        final String path = extractPath(method, http3Headers);
         FullHttpRequest msg = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.valueOf(method
-                        .toString()), path.toString(), content, validateHttpHeaders);
+                        .toString()), path, content, validateHttpHeaders);
         try {
             addHttp3ToHttpHeaders(streamId, http3Headers, msg, false);
         } catch (Http3Exception e) {
@@ -250,10 +258,9 @@ public final class HttpConversionUtil {
         // HTTP/3 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line.
         final CharSequence method = checkNotNull(http3Headers.method(),
                 "method header cannot be null in conversion to HTTP/1.x");
-        final CharSequence path = checkNotNull(http3Headers.path(),
-                "path header cannot be null in conversion to HTTP/1.x");
+        final String path = extractPath(method, http3Headers);
         HttpRequest msg = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.valueOf(method.toString()),
-                path.toString(), validateHttpHeaders);
+                path, validateHttpHeaders);
         try {
             addHttp3ToHttpHeaders(streamId, http3Headers, msg.headers(), msg.protocolVersion(), false, true);
         } catch (Http3Exception e) {

--- a/src/test/java/io/netty/incubator/codec/http3/Http3HeadersSinkTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3HeadersSinkTest.java
@@ -102,6 +102,24 @@ public class Http3HeadersSinkTest {
         sink.finish();
     }
 
+    @Test(expected = Http3HeadersValidationException.class)
+    public void testInvalidPseudoHeadersForConnect() throws Exception {
+        Http3HeadersSink sink = new Http3HeadersSink(new DefaultHttp3Headers(), 512, true);
+        sink.accept(Http3Headers.PseudoHeaderName.METHOD.value(), "CONNECT");
+        sink.accept(Http3Headers.PseudoHeaderName.PATH.value(), "/");
+        sink.accept(Http3Headers.PseudoHeaderName.SCHEME.value(), "https");
+        sink.accept(Http3Headers.PseudoHeaderName.AUTHORITY.value(), "value");
+        sink.finish();
+    }
+
+    @Test
+    public void testValidPseudoHeadersForConnect() throws Exception {
+        Http3HeadersSink sink = new Http3HeadersSink(new DefaultHttp3Headers(), 512, true);
+        sink.accept(Http3Headers.PseudoHeaderName.METHOD.value(), "CONNECT");
+        sink.accept(Http3Headers.PseudoHeaderName.AUTHORITY.value(), "value");
+        sink.finish();
+    }
+
     private static void addMandatoryPseudoHeaders(Http3HeadersSink sink, boolean req) {
         if (req) {
             sink.accept(Http3Headers.PseudoHeaderName.METHOD.value(), "GET");

--- a/src/test/java/io/netty/incubator/codec/http3/HttpConversionUtilTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/HttpConversionUtilTest.java
@@ -17,6 +17,8 @@ package io.netty.incubator.codec.http3;
 
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.AsciiString;
 import org.junit.Test;
@@ -33,11 +35,22 @@ import static io.netty.handler.codec.http.HttpHeaderValues.GZIP;
 import static io.netty.handler.codec.http.HttpHeaderValues.TRAILERS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class HttpConversionUtilTest {
+
+    @Test
+    public void connectNoPath() throws Exception {
+        Http3Headers headers = new DefaultHttp3Headers();
+        headers.method(HttpMethod.CONNECT.asciiName());
+        HttpRequest request = HttpConversionUtil.toHttpRequest(0, headers, true);
+        assertNotNull(request);
+        assertEquals("/", request.uri());
+    }
+
     @Test
     public void setHttp3AuthorityWithoutUserInfo() {
         Http3Headers headers = new DefaultHttp3Headers();


### PR DESCRIPTION
Motivation:

CONNECT requests must not contain path / scheme pseudo headers. Let's validate this and also allow to handle the case when we should convert a CONNECT request to HTTP/1.1 for CONNECT

Modifications:

- Correctly validate CONNECT requests
- Correctly convert CONNECT request
- Add unit tests

Result:

CONNECT is handled correctly