### PR TITLE
Upgrade netty-incubator-codec-quic version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <skipTests>false</skipTests>
     <netty.version>4.1.60.Final</netty.version>
     <netty.build.version>29</netty.build.version>
-    <netty.quic.version>0.0.8.Final</netty.quic.version>
+    <netty.quic.version>0.0.9.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <release.gpg.keyname />
     <release.gpg.passphrase />

--- a/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicStreamChannel.java
+++ b/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicStreamChannel.java
@@ -189,6 +189,11 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
         return shutdown(0, promise);
     }
 
+    @Override
+    public ChannelFuture shutdownOutput(ChannelPromise promise) {
+        return shutdownOutput(0, promise);
+    }
+
     Integer outputShutdownError() {
         return outputShutdown;
     }

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
@@ -38,7 +38,6 @@ import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 
-import io.netty.incubator.codec.quic.QuicStreamFrame;
 import io.netty.util.CharsetUtil;
 import org.junit.Test;
 
@@ -60,7 +59,6 @@ public class Http3FrameToHttpObjectCodecTest {
         assertThat(headersFrame.headers().status().toString(), is("200"));
         assertTrue(ch.isOutputShutdown());
 
-        assertThat(ch.readOutbound(), is(QuicStreamFrame.EMPTY_FIN));
         assertFalse(ch.finish());
     }
 
@@ -106,7 +104,6 @@ public class Http3FrameToHttpObjectCodecTest {
         }
 
         assertTrue(ch.isOutputShutdown());
-        assertThat(ch.readOutbound(), is(QuicStreamFrame.EMPTY_FIN));
         assertFalse(ch.finish());
     }
 
@@ -125,7 +122,6 @@ public class Http3FrameToHttpObjectCodecTest {
         assertThat(trailersFrame.headers().get("key").toString(), is("value"));
         assertTrue(ch.isOutputShutdown());
 
-        assertThat(ch.readOutbound(), is(QuicStreamFrame.EMPTY_FIN));
         assertFalse(ch.finish());
     }
 
@@ -152,7 +148,6 @@ public class Http3FrameToHttpObjectCodecTest {
         assertThat(trailersFrame.headers().get("key").toString(), is("value"));
         assertTrue(ch.isOutputShutdown());
 
-        assertThat(ch.readOutbound(), is(QuicStreamFrame.EMPTY_FIN));
         assertFalse(ch.finish());
     }
 
@@ -199,7 +194,6 @@ public class Http3FrameToHttpObjectCodecTest {
         assertTrue(emptyFrame.headers().isEmpty());
 
         assertTrue(ch.isOutputShutdown());
-        assertThat(ch.readOutbound(), is(QuicStreamFrame.EMPTY_FIN));
         assertFalse(ch.finish());
     }
 
@@ -218,7 +212,6 @@ public class Http3FrameToHttpObjectCodecTest {
         }
 
         assertTrue(ch.isOutputShutdown());
-        assertThat(ch.readOutbound(), is(QuicStreamFrame.EMPTY_FIN));
         assertFalse(ch.finish());
     }
 
@@ -242,7 +235,6 @@ public class Http3FrameToHttpObjectCodecTest {
         assertThat(headerFrame.headers().get("key").toString(), is("value"));
         assertTrue(ch.isOutputShutdown());
 
-        assertThat(ch.readOutbound(), is(QuicStreamFrame.EMPTY_FIN));
         assertFalse(ch.finish());
     }
 
@@ -383,7 +375,6 @@ public class Http3FrameToHttpObjectCodecTest {
         assertThat(headers.path().toString(), is("/hello/world"));
         assertTrue(ch.isOutputShutdown());
 
-        assertThat(ch.readOutbound(), is(QuicStreamFrame.EMPTY_FIN));
         assertFalse(ch.finish());
     }
 
@@ -409,7 +400,6 @@ public class Http3FrameToHttpObjectCodecTest {
         }
 
         assertTrue(ch.isOutputShutdown());
-        assertThat(ch.readOutbound(), is(QuicStreamFrame.EMPTY_FIN));
         assertFalse(ch.finish());
     }
 
@@ -434,7 +424,6 @@ public class Http3FrameToHttpObjectCodecTest {
         assertThat(trailersFrame.headers().get("key").toString(), is("value"));
 
         assertTrue(ch.isOutputShutdown());
-        assertThat(ch.readOutbound(), is(QuicStreamFrame.EMPTY_FIN));
         assertFalse(ch.finish());
     }
 
@@ -467,7 +456,6 @@ public class Http3FrameToHttpObjectCodecTest {
         assertThat(trailersFrame.headers().get("key").toString(), is("value"));
 
         assertTrue(ch.isOutputShutdown());
-        assertThat(ch.readOutbound(), is(QuicStreamFrame.EMPTY_FIN));
         assertFalse(ch.finish());
     }
 
@@ -517,7 +505,6 @@ public class Http3FrameToHttpObjectCodecTest {
         assertTrue(emptyFrame.headers().isEmpty());
 
         assertTrue(ch.isOutputShutdown());
-        assertThat(ch.readOutbound(), is(QuicStreamFrame.EMPTY_FIN));
         assertFalse(ch.finish());
     }
 
@@ -536,7 +523,6 @@ public class Http3FrameToHttpObjectCodecTest {
         }
 
         assertTrue(ch.isOutputShutdown());
-        assertThat(ch.readOutbound(), is(QuicStreamFrame.EMPTY_FIN));
         assertFalse(ch.finish());
     }
 
@@ -552,7 +538,6 @@ public class Http3FrameToHttpObjectCodecTest {
         assertThat(headerFrame.headers().get("key").toString(), is("value"));
 
         assertTrue(ch.isOutputShutdown());
-        assertThat(ch.readOutbound(), is(QuicStreamFrame.EMPTY_FIN));
         assertFalse(ch.finish());
     }
 
@@ -576,7 +561,6 @@ public class Http3FrameToHttpObjectCodecTest {
         assertThat(headerFrame.headers().get("key").toString(), is("value"));
 
         assertTrue(ch.isOutputShutdown());
-        assertThat(ch.readOutbound(), is(QuicStreamFrame.EMPTY_FIN));
         assertFalse(ch.finish());
     }
 

--- a/src/test/java/io/netty/incubator/codec/http3/example/Http3ClientExample.java
+++ b/src/test/java/io/netty/incubator/codec/http3/example/Http3ClientExample.java
@@ -98,7 +98,7 @@ public final class Http3ClientExample {
             Http3HeadersFrame frame = new DefaultHttp3HeadersFrame();
             frame.headers().method("GET").path("/");
             streamChannel.writeAndFlush(frame)
-                    .addListener(QuicStreamChannel.WRITE_FIN).sync();
+                    .addListener(QuicStreamChannel.SHUTDOWN_OUTPUT).sync();
 
             // Wait for the stream channel and quic channel to be closed (this will happen after we received the FIN).
             // After this is done we will close the underlying datagram channel.

--- a/src/test/java/io/netty/incubator/codec/http3/example/Http3ServerExample.java
+++ b/src/test/java/io/netty/incubator/codec/http3/example/Http3ServerExample.java
@@ -96,7 +96,7 @@ public final class Http3ServerExample {
                                                 ctx.write(headersFrame);
                                                 ctx.writeAndFlush(new DefaultHttp3DataFrame(
                                                         Unpooled.wrappedBuffer(CONTENT)))
-                                                        .addListener(QuicStreamChannel.WRITE_FIN);
+                                                        .addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
                                             }
                                         });
                                     }


### PR DESCRIPTION
Motivation:

A new netty-incubator-codec-quic version was released.

Modifications:

- Upgrade to new version
- Adjust test code
- Adjust examples

Result:

Use latest quic release