### PR TITLE
Correctly set path when convert CONNECT requests

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/HttpConversionUtil.java
+++ b/src/main/java/io/netty/incubator/codec/http3/HttpConversionUtil.java
@@ -197,12 +197,14 @@ public final class HttpConversionUtil {
         return msg;
     }
 
-    private static String extractPath(CharSequence method, Http3Headers headers) {
+    private static CharSequence extractPath(CharSequence method, Http3Headers headers) {
         if (HttpMethod.CONNECT.asciiName().contentEqualsIgnoreCase(method)) {
-            return "/";
+            // See https://tools.ietf.org/html/rfc7231#section-4.3.6
+            return checkNotNull(headers.authority(),
+                    "authority header cannot be null in the conversion to HTTP/1.x");
         } else {
             return checkNotNull(headers.path(),
-                    "path header cannot be null in conversion to HTTP/1.x").toString();
+                    "path header cannot be null in conversion to HTTP/1.x");
         }
     }
 
@@ -225,9 +227,9 @@ public final class HttpConversionUtil {
         // HTTP/3 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line.
         final CharSequence method = checkNotNull(http3Headers.method(),
                 "method header cannot be null in conversion to HTTP/1.x");
-        final String path = extractPath(method, http3Headers);
+        final CharSequence path = extractPath(method, http3Headers);
         FullHttpRequest msg = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.valueOf(method
-                        .toString()), path, content, validateHttpHeaders);
+                        .toString()), path.toString(), content, validateHttpHeaders);
         try {
             addHttp3ToHttpHeaders(streamId, http3Headers, msg, false);
         } catch (Http3Exception e) {
@@ -258,9 +260,9 @@ public final class HttpConversionUtil {
         // HTTP/3 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line.
         final CharSequence method = checkNotNull(http3Headers.method(),
                 "method header cannot be null in conversion to HTTP/1.x");
-        final String path = extractPath(method, http3Headers);
+        final CharSequence path = extractPath(method, http3Headers);
         HttpRequest msg = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.valueOf(method.toString()),
-                path, validateHttpHeaders);
+                path.toString(), validateHttpHeaders);
         try {
             addHttp3ToHttpHeaders(streamId, http3Headers, msg.headers(), msg.protocolVersion(), false, true);
         } catch (Http3Exception e) {

--- a/src/test/java/io/netty/incubator/codec/http3/HttpConversionUtilTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/HttpConversionUtilTest.java
@@ -44,11 +44,14 @@ public class HttpConversionUtilTest {
 
     @Test
     public void connectNoPath() throws Exception {
+        String authority = "netty.io:80";
         Http3Headers headers = new DefaultHttp3Headers();
+        headers.authority(authority);
         headers.method(HttpMethod.CONNECT.asciiName());
         HttpRequest request = HttpConversionUtil.toHttpRequest(0, headers, true);
         assertNotNull(request);
-        assertEquals("/", request.uri());
+        assertEquals(authority, request.uri());
+        assertEquals(authority, request.headers().get(HOST));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

35e54cbf74505c8e2880f980440429af96c5102c did some changes to support CONNECT requests in the convertation layer. This fix there was not 100 % correct as it turned out.

Modifications:

- Use the :authority for the CONNECT uri
- Adjust test case

Result:

Correctly support CONNECT