### PR TITLE
Add mandatory pseudo headers in example

### DIFF
--- a/src/test/java/io/netty/incubator/codec/http3/example/Http3ClientExample.java
+++ b/src/test/java/io/netty/incubator/codec/http3/example/Http3ClientExample.java
@@ -65,7 +65,7 @@ public final class Http3ClientExample {
 
             QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
                     .handler(new Http3ClientConnectionHandler())
-                    .remoteAddress(new InetSocketAddress(NetUtil.LOCALHOST4, 9999))
+                    .remoteAddress(new InetSocketAddress(NetUtil.LOCALHOST4, Http3ServerExample.PORT))
                     .connect()
                     .get();
 
@@ -96,7 +96,9 @@ public final class Http3ClientExample {
             // Write the Header frame and send the FIN to mark the end of the request.
             // After this its not possible anymore to write any more data.
             Http3HeadersFrame frame = new DefaultHttp3HeadersFrame();
-            frame.headers().method("GET").path("/");
+            frame.headers().method("GET").path("/")
+                    .authority(NetUtil.LOCALHOST4.getHostAddress() + ":" + Http3ServerExample.PORT)
+                    .scheme("https");
             streamChannel.writeAndFlush(frame)
                     .addListener(QuicStreamChannel.SHUTDOWN_OUTPUT).sync();
 

--- a/src/test/java/io/netty/incubator/codec/http3/example/Http3ServerExample.java
+++ b/src/test/java/io/netty/incubator/codec/http3/example/Http3ServerExample.java
@@ -44,6 +44,8 @@ import java.util.concurrent.TimeUnit;
 
 public final class Http3ServerExample {
     private static final byte[] CONTENT = "Hello World!\r\n".getBytes(CharsetUtil.US_ASCII);
+    static final int PORT = 9999;
+
     private Http3ServerExample() { }
 
     public static void main(String... args) throws Exception {
@@ -108,7 +110,7 @@ public final class Http3ServerExample {
             Channel channel = bs.group(group)
                     .channel(NioDatagramChannel.class)
                     .handler(codec)
-                    .bind(new InetSocketAddress(9999)).sync().channel();
+                    .bind(new InetSocketAddress(PORT)).sync().channel();
             channel.closeFuture().sync();
         } finally {
             group.shutdownGracefully();


### PR DESCRIPTION
__Motivation__

https://github.com/netty/netty-incubator-codec-http3/pull/98 added validation for mandatory pseudo headers but missed adding the headers to the example. The client request from the example is now rejected by the server.

__Modification__

Add the mandatory pseudo headers (`authority` and `scheme`) in `Http3ClientExample`.

__Result__

Example works as expected.