### PR TITLE
Update to latest quic release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <skipTests>false</skipTests>
     <netty.version>4.1.61.Final</netty.version>
     <netty.build.version>29</netty.build.version>
-    <netty.quic.version>0.0.9.Final</netty.quic.version>
+    <netty.quic.version>0.0.10.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <release.gpg.keyname />
     <release.gpg.passphrase />


### PR DESCRIPTION
Motivation:

We did a new netty-incubator-codec-quic release. Let's upgrade

Modifications:

Upgrade to 0.0.10.Final

Result:

Use latest netty quic release