### PR TITLE
Run h3spec during tests

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -27,7 +27,7 @@ jobs:
             ${{ runner.os }}-pr-${{ env.cache-name }}-
             ${{ runner.os }}-pr-
       - name: Verify with Maven
-        run: mvn verify -B --file pom.xml -DskipTests=true
+        run: mvn verify -B --file pom.xml -DskipTests=true -DskipH3Spec=true
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -45,7 +45,7 @@ jobs:
             }]
 
       - name: Prepare release with Maven
-        run:  mvn -B --file pom.xml release:prepare -DpreparationGoals=clean -DskipTests=true
+        run:  mvn -B --file pom.xml release:prepare -DpreparationGoals=clean -DskipTests=true -DskipH3Spec=true
 
       - name: Perform release with Maven
         run: mvn -B --file pom.xml release:perform -Drelease.gpg.keyname=${{ secrets.GPG_KEYNAME }} -Drelease.gpg.passphrase=${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -60,7 +60,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Build project
-      run: ./mvnw clean package -DskipTests=true
+      run: ./mvnw clean package -DskipTests=true -DskipH3Spec=true
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/pom.xml
+++ b/pom.xml
@@ -303,8 +303,9 @@
       <plugin>
         <groupId>io.netty.incubator</groupId>
         <artifactId>netty-incubator-h3spec-maven-plugin</artifactId>
-        <version>0.0.3.Final</version>
+        <version>0.0.4.Final</version>
         <configuration>
+          <delay>1000</delay>
           <mainClass>io.netty.incubator.codec.http3.example.Http3ServerExample</mainClass>
           <excludeSpecs>
             <!-- Let's only run the HTTP3 tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     <release.gpg.keyname />
     <release.gpg.passphrase />
     <test.argLine>-D_</test.argLine>
+    <skipH3Spec>false</skipH3Spec>
   </properties>
 
   <build>
@@ -298,6 +299,28 @@
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.2.0</version>
+      </plugin>
+      <plugin>
+        <groupId>io.netty.incubator</groupId>
+        <artifactId>netty-incubator-h3spec-maven-plugin</artifactId>
+        <version>0.0.3.Final</version>
+        <configuration>
+          <mainClass>io.netty.incubator.codec.http3.example.Http3ServerExample</mainClass>
+          <excludeSpecs>
+            <!-- Let's only run the HTTP3 tests -->
+            <excludeSpec>/QUIC</excludeSpec>
+          </excludeSpecs>
+
+          <skip>${skipH3Spec}</skip>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>h3spec</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/test/java/io/netty/incubator/codec/http3/example/Http3ServerExample.java
+++ b/src/test/java/io/netty/incubator/codec/http3/example/Http3ServerExample.java
@@ -49,6 +49,13 @@ public final class Http3ServerExample {
     private Http3ServerExample() { }
 
     public static void main(String... args) throws Exception {
+        int port;
+        // Allow to pass in the port so we can also use it to run h3spec against
+        if (args.length == 1) {
+            port = Integer.parseInt(args[0]);
+        } else {
+            port = PORT;
+        }
         NioEventLoopGroup group = new NioEventLoopGroup(1);
         SelfSignedCertificate cert = new SelfSignedCertificate();
         QuicSslContext sslContext = QuicSslContextBuilder.forServer(cert.key(), null, cert.cert())
@@ -110,7 +117,7 @@ public final class Http3ServerExample {
             Channel channel = bs.group(group)
                     .channel(NioDatagramChannel.class)
                     .handler(codec)
-                    .bind(new InetSocketAddress(PORT)).sync().channel();
+                    .bind(new InetSocketAddress(port)).sync().channel();
             channel.closeFuture().sync();
         } finally {
             group.shutdownGracefully();


### PR DESCRIPTION
Motivation:

We recently release a maven plugin that can be used to run h3spec during the tests. Let's use it

Modifications:

- Add plugin config to the pom.xml
- Adjust example code to be able to pass in the port

Result:

Run h3spec tests