### PR TITLE
Fix incorrect `increment` handling in `QpackDecoderHandler`

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/QpackDecoderHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackDecoderHandler.java
@@ -79,16 +79,25 @@ final class QpackDecoderHandler extends ByteToMessageDecoder {
         // +---+---+-----------------------+
         if ((b & 0b1100_0000) == 0b0000_0000) {
             long increment = QpackUtil.decodePrefixedInteger(in, 6);
-            if (increment <= 0) {
+            if (increment == 0) {
                 discard = true;
+                // Zero is not allowed as an increment
+                // https://quicwg.org/base-drafts/draft-ietf-quic-qpack.html#name-insert-count-increment
+                // Increment is an unsigned integer, so only 0 is the invalid value.
+                // https://www.rfc-editor.org/rfc/rfc7541#section-5
                 Http3CodecUtils.connectionError(ctx, Http3ErrorCode.QPACK_DECODER_STREAM_ERROR,
                         "Invalid increment '" + increment + "'.",  false);
                 return;
+            } else if (increment < 0) {
+                return;
             }
+            // Do nothing for now
             return;
         }
-        // TODO: Handle me
-        in.skipBytes(in.readableBytes());
+        // unknown frame
+        discard = true;
+        Http3CodecUtils.connectionError(ctx, Http3ErrorCode.QPACK_DECODER_STREAM_ERROR,
+                "Unknown decoder instruction '" + b + "'.",  false);
     }
 
     @Override

--- a/src/main/java/io/netty/incubator/codec/http3/QpackDecoderHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackDecoderHandler.java
@@ -88,7 +88,8 @@ final class QpackDecoderHandler extends ByteToMessageDecoder {
                 Http3CodecUtils.connectionError(ctx, Http3ErrorCode.QPACK_DECODER_STREAM_ERROR,
                         "Invalid increment '" + increment + "'.",  false);
                 return;
-            } else if (increment < 0) {
+            }
+            if (increment < 0) {
                 return;
             }
             // Do nothing for now


### PR DESCRIPTION
__Motivation__

`QpackDecoderHandler` incorrectly assumes negative value from `QpackUtil.decodePrefixedInteger()` to be read from the `ByteBuf`. The method returns `-1` if there isn't enough data available in the buffer to read a prefixed integer.

__Modification__

- As prefixed integers are unsigned integers, only `0` is an invalid value. Fixed the check accordingly.
- Also, fix the TODO for unknown frame by closing the connection.

__Result__

 `QpackDecoderHandler` can now handle decoding an insert count increment frame split across multiple buffers.