### PR TITLE
Add missing Name Index handling in `QpackEncoderHandler`

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/QpackEncoderHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackEncoderHandler.java
@@ -79,8 +79,11 @@ final class QpackEncoderHandler extends ByteToMessageDecoder {
         //   +-------------------------------+
         if ((b & 0b1000_0000) == 0b1000_0000) {
             int readerIndex = in.readerIndex();
-            // Just skip the first byte for now
-            in.readerIndex(readerIndex + 1);
+            final long nameIdx = QpackUtil.decodePrefixedInteger(in, 6);
+            if (nameIdx < 0) {
+                // Not enough readable bytes
+                return;
+            }
 
             long length = QpackUtil.decodePrefixedInteger(in, 7);
             if (length < 0) {


### PR DESCRIPTION
__Motivation__

For "Insert With Name Reference" frames, `QpackEncoderHandler` does not read the name index.

__Modification__

- Read name index from the buffer before reading the value length.

__Result__

 `QpackDecoderHandler` correctly handles "Insert With Name Reference" frame decoding.