### PR TITLE
Introduce `EmbeddedQuicChannel`

### DIFF
--- a/src/test/java/io/netty/incubator/codec/http3/AbtractHttp3ConnectionHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/AbtractHttp3ConnectionHandlerTest.java
@@ -40,11 +40,16 @@ public abstract class AbtractHttp3ConnectionHandlerTest {
         handler.channelRegistered(ctx);
         handler.channelActive(ctx);
 
+        final EmbeddedQuicStreamChannel localControlStream = quicChannel.localControlStream();
+        assertNotNull(localControlStream);
+
         assertNotNull(Http3.getLocalControlStream(quicChannel));
 
         handler.channelInactive(ctx);
         handler.channelUnregistered(ctx);
         handler.handlerRemoved(ctx);
+
+        localControlStream.finishAndReleaseAll();
     }
 
     @Test
@@ -60,12 +65,17 @@ public abstract class AbtractHttp3ConnectionHandlerTest {
         handler.channelRegistered(ctx);
         handler.channelActive(ctx);
 
+        final EmbeddedQuicStreamChannel localControlStream = quicChannel.localControlStream();
+        assertNotNull(localControlStream);
+
         handler.channelRead(ctx, bidirectionalStream);
 
         assertBidirectionalStreamHandled(quicChannel, bidirectionalStream);
         handler.channelInactive(ctx);
         handler.channelUnregistered(ctx);
         handler.handlerRemoved(ctx);
+
+        localControlStream.finishAndReleaseAll();
     }
 
     @Test
@@ -80,6 +90,9 @@ public abstract class AbtractHttp3ConnectionHandlerTest {
         handler.channelRegistered(ctx);
         handler.channelActive(ctx);
 
+        final EmbeddedQuicStreamChannel localControlStream = quicChannel.localControlStream();
+        assertNotNull(localControlStream);
+
         handler.channelRead(ctx, unidirectionalStream);
 
         assertNotNull(unidirectionalStream.pipeline().get(Http3UnidirectionalStreamInboundHandler.class));
@@ -87,5 +100,7 @@ public abstract class AbtractHttp3ConnectionHandlerTest {
         handler.channelInactive(ctx);
         handler.channelUnregistered(ctx);
         handler.handlerRemoved(ctx);
+
+        localControlStream.finishAndReleaseAll();
     }
 }

--- a/src/test/java/io/netty/incubator/codec/http3/AbtractHttp3ConnectionHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/AbtractHttp3ConnectionHandlerTest.java
@@ -15,54 +15,32 @@
  */
 package io.netty.incubator.codec.http3;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.UnpooledByteBufAllocator;
-import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPipeline;
-import io.netty.channel.DefaultChannelPipeline;
-import io.netty.channel.DefaultChannelPromise;
-import io.netty.incubator.codec.quic.QuicChannel;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.incubator.codec.quic.QuicStreamType;
-import io.netty.util.AttributeMap;
-import io.netty.util.DefaultAttributeMap;
-import io.netty.util.concurrent.ImmediateEventExecutor;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public abstract class AbtractHttp3ConnectionHandlerTest {
 
     protected abstract Http3ConnectionHandler newConnectionHandler();
 
-    protected abstract void assertBidirectionalStreamHandled(QuicChannel channel, QuicStreamChannel streamChannel);
+    protected abstract void assertBidirectionalStreamHandled(EmbeddedQuicChannel channel,
+                                                             QuicStreamChannel streamChannel);
 
     @Test
     public void testOpenLocalControlStream() throws Exception {
-        QuicChannel quicChannel = mock(QuicChannel.class);
-        QuicStreamChannel localControlStreamChannel = mock(QuicStreamChannel.class);
-        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        EmbeddedQuicChannel quicChannel = new EmbeddedQuicChannel(new ChannelDuplexHandler());
+        ChannelHandlerContext ctx = quicChannel.pipeline().firstContext();
 
-        AttributeMap attributeMap = new DefaultAttributeMap();
-        when(quicChannel.attr(any())).then(a -> attributeMap.attr(a.getArgument(0)));
-        when(quicChannel.createStream(any(QuicStreamType.class), any(ChannelHandler.class)))
-                .thenReturn(ImmediateEventExecutor.INSTANCE.newSucceededFuture(localControlStreamChannel));
-
-        when(ctx.channel()).thenReturn(quicChannel);
         Http3ConnectionHandler handler = newConnectionHandler();
         handler.handlerAdded(ctx);
         handler.channelRegistered(ctx);
         handler.channelActive(ctx);
 
-        assertEquals(localControlStreamChannel, Http3.getLocalControlStream(quicChannel));
+        assertNotNull(Http3.getLocalControlStream(quicChannel));
 
         handler.channelInactive(ctx);
         handler.channelUnregistered(ctx);
@@ -71,27 +49,11 @@ public abstract class AbtractHttp3ConnectionHandlerTest {
 
     @Test
     public void testBidirectionalStream() throws Exception {
-        QuicChannel quicChannel = mock(QuicChannel.class);
-        QuicStreamChannel localControlStreamChannel = mock(QuicStreamChannel.class);
-        QuicStreamChannel bidirectionalStream = mock(QuicStreamChannel.class);
-
-        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
-
-        AttributeMap attributeMap = new DefaultAttributeMap();
-        when(quicChannel.attr(any())).then(a -> attributeMap.attr(a.getArgument(0)));
-        when(quicChannel.createStream(any(QuicStreamType.class), any(ChannelHandler.class)))
-                .thenReturn(ImmediateEventExecutor.INSTANCE.newSucceededFuture(localControlStreamChannel));
-        when(quicChannel.close(anyBoolean(), anyInt(),
-                any(ByteBuf.class))).thenReturn(new DefaultChannelPromise(quicChannel));
-        when(quicChannel.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
-
-        when(ctx.channel()).thenReturn(quicChannel);
-
-        when(bidirectionalStream.type()).thenReturn(QuicStreamType.BIDIRECTIONAL);
-        when(bidirectionalStream.parent()).thenReturn(quicChannel);
-
-        ChannelPipeline pipeline = new DefaultChannelPipeline(bidirectionalStream) { };
-        when(bidirectionalStream.pipeline()).thenReturn(pipeline);
+        EmbeddedQuicChannel quicChannel = new EmbeddedQuicChannel(new ChannelDuplexHandler());
+        final EmbeddedQuicStreamChannel bidirectionalStream =
+                (EmbeddedQuicStreamChannel) quicChannel.createStream(QuicStreamType.BIDIRECTIONAL,
+                        new ChannelDuplexHandler()).get();
+        ChannelHandlerContext ctx = quicChannel.pipeline().firstContext();
 
         Http3ConnectionHandler handler = newConnectionHandler();
         handler.handlerAdded(ctx);
@@ -108,25 +70,10 @@ public abstract class AbtractHttp3ConnectionHandlerTest {
 
     @Test
     public void testUnidirectionalStream() throws Exception {
-        QuicChannel quicChannel = mock(QuicChannel.class);
-        QuicStreamChannel localControlStream = mock(QuicStreamChannel.class);
-        QuicStreamChannel unidirectionalStream = mock(QuicStreamChannel.class);
-
-        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
-
-        AttributeMap attributeMap = new DefaultAttributeMap();
-        when(quicChannel.attr(any())).then(a -> attributeMap.attr(a.getArgument(0)));
-        when(quicChannel.createStream(any(QuicStreamType.class), any(ChannelHandler.class)))
-                .thenReturn(ImmediateEventExecutor.INSTANCE.newSucceededFuture(localControlStream));
-        when(quicChannel.close(anyBoolean(), anyInt(),
-                any(ByteBuf.class))).thenReturn(new DefaultChannelPromise(quicChannel));
-        when(quicChannel.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
-
-        when(ctx.channel()).thenReturn(quicChannel);
-
-        ChannelPipeline pipeline = new DefaultChannelPipeline(unidirectionalStream) { };
-        when(unidirectionalStream.pipeline()).thenReturn(pipeline);
-        when(unidirectionalStream.type()).thenReturn(QuicStreamType.UNIDIRECTIONAL);
+        EmbeddedQuicChannel quicChannel = new EmbeddedQuicChannel(new ChannelDuplexHandler());
+        final QuicStreamChannel unidirectionalStream =
+                quicChannel.createStream(QuicStreamType.UNIDIRECTIONAL, new ChannelDuplexHandler()).get();
+        ChannelHandlerContext ctx = quicChannel.pipeline().firstContext();
 
         Http3ConnectionHandler handler = newConnectionHandler();
         handler.handlerAdded(ctx);
@@ -135,7 +82,7 @@ public abstract class AbtractHttp3ConnectionHandlerTest {
 
         handler.channelRead(ctx, unidirectionalStream);
 
-        assertNotNull(pipeline.get(Http3UnidirectionalStreamInboundHandler.class));
+        assertNotNull(unidirectionalStream.pipeline().get(Http3UnidirectionalStreamInboundHandler.class));
 
         handler.channelInactive(ctx);
         handler.channelUnregistered(ctx);

--- a/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicChannel.java
+++ b/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicChannel.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.http3;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelId;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.WriteBufferWaterMark;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.incubator.codec.quic.QuicChannelConfig;
+import io.netty.incubator.codec.quic.QuicConnectionStats;
+import io.netty.incubator.codec.quic.QuicStreamChannel;
+import io.netty.incubator.codec.quic.QuicStreamType;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import static java.util.Collections.unmodifiableCollection;
+
+final class EmbeddedQuicChannel extends EmbeddedChannel implements QuicChannel {
+    private static final AtomicLongFieldUpdater<EmbeddedQuicChannel> streamIdUpdater =
+            AtomicLongFieldUpdater.newUpdater(EmbeddedQuicChannel.class, "streamId");
+
+    private volatile long streamId;
+    private final Map<QuicStreamType, Long> peerAllowedStreams = new EnumMap<>(QuicStreamType.class);
+    private final AtomicBoolean closed = new AtomicBoolean();
+    private final ConcurrentLinkedQueue<Integer> closeErrorCodes = new ConcurrentLinkedQueue<>();
+    private QuicChannelConfig config;
+
+    EmbeddedQuicChannel(ChannelHandler... handlers) {
+        super(handlers);
+    }
+
+    EmbeddedQuicChannel(Channel parent, ChannelId channelId, boolean register, boolean hasDisconnect,
+                        ChannelHandler... handlers) {
+        super(parent, channelId, register, hasDisconnect, handlers);
+    }
+
+    @Override
+    public QuicChannelConfig config() {
+        if (config == null) {
+            config = new EmbeddedQuicChannelConfig(super.config());
+        }
+        return config;
+    }
+
+    @Override
+    public QuicChannel flush() {
+        super.flush();
+        return this;
+    }
+
+    @Override
+    public QuicChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
+    public long peerAllowedStreams(QuicStreamType type) {
+        return peerAllowedStreams.getOrDefault(type, Long.MAX_VALUE);
+    }
+
+    public void peerAllowedStreams(QuicStreamType type, long peerAllowedStreams) {
+        this.peerAllowedStreams.put(type, peerAllowedStreams);
+    }
+
+    @Override
+    public Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler,
+                                                  Promise<QuicStreamChannel> promise) {
+        promise.setSuccess(new EmbeddedQuicStreamChannel(this, true, type,
+                streamIdUpdater.getAndAdd(this, 2), handler));
+        return promise;
+    }
+
+    @Override
+    public ChannelFuture close(boolean applicationClose, int error, ByteBuf reason, ChannelPromise promise) {
+        closeErrorCodes.add(error);
+        if (closed.compareAndSet(false, true)) {
+            promise.addListener(__ -> reason.release());
+        } else {
+            reason.release();
+        }
+        return close(promise);
+    }
+
+    @Override
+    public Future<QuicConnectionStats> collectStats(Promise<QuicConnectionStats> promise) {
+        promise.setFailure(new UnsupportedOperationException("Collect stats not supported for embedded channel."));
+        return promise;
+    }
+
+    Collection<Integer> closeErrorCodes() {
+        return unmodifiableCollection(closeErrorCodes);
+    }
+
+    private static final class EmbeddedQuicChannelConfig implements QuicChannelConfig {
+        private final ChannelConfig delegate;
+
+        EmbeddedQuicChannelConfig(ChannelConfig delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Map<ChannelOption<?>, Object> getOptions() {
+            return delegate.getOptions();
+        }
+
+        @Override
+        public boolean setOptions(Map<ChannelOption<?>, ?> map) {
+            return delegate.setOptions(map);
+        }
+
+        @Override
+        public <T> T getOption(ChannelOption<T> channelOption) {
+            return delegate.getOption(channelOption);
+        }
+
+        @Override
+        public <T> boolean setOption(ChannelOption<T> channelOption, T t) {
+            return delegate.setOption(channelOption, t);
+        }
+
+        @Override
+        public int getConnectTimeoutMillis() {
+            return delegate.getConnectTimeoutMillis();
+        }
+
+        @Override
+        public QuicChannelConfig setConnectTimeoutMillis(int i) {
+            delegate.setConnectTimeoutMillis(i);
+            return this;
+        }
+
+        @Override
+        @Deprecated
+        public int getMaxMessagesPerRead() {
+            return delegate.getMaxMessagesPerRead();
+        }
+
+        @Override
+        @Deprecated
+        public QuicChannelConfig setMaxMessagesPerRead(int i) {
+            delegate.setMaxMessagesPerRead(i);
+            return this;
+        }
+
+        @Override
+        public int getWriteSpinCount() {
+            return delegate.getWriteSpinCount();
+        }
+
+        @Override
+        public QuicChannelConfig setWriteSpinCount(int i) {
+            delegate.setWriteSpinCount(i);
+            return this;
+        }
+
+        @Override
+        public ByteBufAllocator getAllocator() {
+            return delegate.getAllocator();
+        }
+
+        @Override
+        public QuicChannelConfig setAllocator(ByteBufAllocator byteBufAllocator) {
+            delegate.setAllocator(byteBufAllocator);
+            return this;
+        }
+
+        @Override
+        public <T extends RecvByteBufAllocator> T getRecvByteBufAllocator() {
+            return delegate.getRecvByteBufAllocator();
+        }
+
+        @Override
+        public QuicChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator recvByteBufAllocator) {
+            delegate.setRecvByteBufAllocator(recvByteBufAllocator);
+            return this;
+        }
+
+        @Override
+        public boolean isAutoRead() {
+            return delegate.isAutoRead();
+        }
+
+        @Override
+        public QuicChannelConfig setAutoRead(boolean b) {
+            delegate.setAutoRead(b);
+            return this;
+        }
+
+        @Override
+        public boolean isAutoClose() {
+            return delegate.isAutoClose();
+        }
+
+        @Override
+        public QuicChannelConfig setAutoClose(boolean b) {
+            delegate.setAutoClose(b);
+            return this;
+        }
+
+        @Override
+        public int getWriteBufferHighWaterMark() {
+            return delegate.getWriteBufferHighWaterMark();
+        }
+
+        @Override
+        public QuicChannelConfig setWriteBufferHighWaterMark(int i) {
+            delegate.setWriteBufferHighWaterMark(i);
+            return this;
+        }
+
+        @Override
+        public int getWriteBufferLowWaterMark() {
+            return delegate.getWriteBufferLowWaterMark();
+        }
+
+        @Override
+        public QuicChannelConfig setWriteBufferLowWaterMark(int i) {
+            delegate.setWriteBufferLowWaterMark(i);
+            return this;
+        }
+
+        @Override
+        public MessageSizeEstimator getMessageSizeEstimator() {
+            return delegate.getMessageSizeEstimator();
+        }
+
+        @Override
+        public QuicChannelConfig setMessageSizeEstimator(MessageSizeEstimator messageSizeEstimator) {
+            delegate.setMessageSizeEstimator(messageSizeEstimator);
+            return this;
+        }
+
+        @Override
+        public WriteBufferWaterMark getWriteBufferWaterMark() {
+            return delegate.getWriteBufferWaterMark();
+        }
+
+        @Override
+        public QuicChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
+            delegate.setWriteBufferWaterMark(writeBufferWaterMark);
+            return this;
+        }
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicChannel.java
+++ b/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicChannel.java
@@ -117,6 +117,10 @@ final class EmbeddedQuicChannel extends EmbeddedChannel implements QuicChannel {
                 new UnsupportedOperationException("Collect stats not supported for embedded channel."));
     }
 
+    public EmbeddedQuicStreamChannel localControlStream() {
+        return (EmbeddedQuicStreamChannel) Http3.getLocalControlStream(this);
+    }
+
     Collection<Integer> closeErrorCodes() {
         return unmodifiableCollection(closeErrorCodes);
     }

--- a/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicChannel.java
+++ b/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicChannel.java
@@ -96,9 +96,8 @@ final class EmbeddedQuicChannel extends EmbeddedChannel implements QuicChannel {
     @Override
     public Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler,
                                                   Promise<QuicStreamChannel> promise) {
-        promise.setSuccess(new EmbeddedQuicStreamChannel(this, true, type,
+        return promise.setSuccess(new EmbeddedQuicStreamChannel(this, true, type,
                 streamIdUpdater.getAndAdd(this, 2), handler));
-        return promise;
     }
 
     @Override
@@ -114,8 +113,8 @@ final class EmbeddedQuicChannel extends EmbeddedChannel implements QuicChannel {
 
     @Override
     public Future<QuicConnectionStats> collectStats(Promise<QuicConnectionStats> promise) {
-        promise.setFailure(new UnsupportedOperationException("Collect stats not supported for embedded channel."));
-        return promise;
+        return promise.setFailure(
+                new UnsupportedOperationException("Collect stats not supported for embedded channel."));
     }
 
     Collection<Integer> closeErrorCodes() {

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ClientConnectionHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ClientConnectionHandlerTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty.incubator.codec.http3;
 
-import io.netty.incubator.codec.quic.QuicChannel;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 
 public class Http3ClientConnectionHandlerTest extends AbtractHttp3ConnectionHandlerTest {
@@ -26,7 +25,7 @@ public class Http3ClientConnectionHandlerTest extends AbtractHttp3ConnectionHand
     }
 
     @Override
-    protected void assertBidirectionalStreamHandled(QuicChannel channel, QuicStreamChannel streamChannel) {
+    protected void assertBidirectionalStreamHandled(EmbeddedQuicChannel channel, QuicStreamChannel streamChannel) {
         Http3TestUtils.verifyClose(Http3ErrorCode.H3_STREAM_CREATION_ERROR, channel);
     }
 }

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamOutboundHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamOutboundHandlerTest.java
@@ -16,24 +16,19 @@
 package io.netty.incubator.codec.http3;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.incubator.codec.quic.QuicChannel;
 import io.netty.util.ReferenceCountUtil;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.List;
 
 import static io.netty.incubator.codec.http3.Http3TestUtils.assertException;
-import static io.netty.incubator.codec.http3.Http3TestUtils.mockParent;
 import static io.netty.incubator.codec.http3.Http3TestUtils.verifyClose;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -57,20 +52,31 @@ public class Http3ControlStreamOutboundHandlerTest extends
         return Arrays.asList(Http3TestUtils.newHttp3RequestStreamFrame(), Http3TestUtils.newHttp3PushStreamFrame());
     }
 
+    @Override
+    public void testValidTypeInbound() {
+        super.testValidTypeInbound();
+    }
+
+    @Override
+    public void testValidTypeOutput() {
+        super.testValidTypeOutput();
+    }
+
     @Test
     public void testStreamClosedWhileParentStillActive() {
-        QuicChannel parent = mockParent();
-        EmbeddedChannel channel = newChannel(parent, newHandler(), true);
+        EmbeddedQuicChannel parent = new EmbeddedQuicChannel();
+        EmbeddedChannel channel = newChannel(parent, newHandler());
         assertFalse(channel.finish());
         verifyClose(1, Http3ErrorCode.H3_CLOSED_CRITICAL_STREAM, parent);
     }
 
     @Test
-    public void testGoAwayIdDecreaseWorks() {
-        QuicChannel parent = mockParent();
+    public void testGoAwayIdDecreaseWorks() throws Exception {
+        EmbeddedQuicChannel parent = new EmbeddedQuicChannel();
+        parent.close().get();
         // Let's mark the parent as inactive before we close as otherwise we will send a close frame.
         EmbeddedChannel channel = newChannel(parent, new Http3ControlStreamOutboundHandler(
-                true, settingsFrame, new ChannelInboundHandlerAdapter()), false);
+                true, settingsFrame, new ChannelInboundHandlerAdapter()));
         assertTrue(channel.writeOutbound(new DefaultHttp3GoAwayFrame(8)));
         ReferenceCountUtil.release(channel.readOutbound());
         assertTrue(channel.writeOutbound(new DefaultHttp3GoAwayFrame(4)));
@@ -80,11 +86,12 @@ public class Http3ControlStreamOutboundHandlerTest extends
     }
 
     @Test
-    public void testGoAwayIdIncreaseFails() {
-        QuicChannel parent = mockParent();
+    public void testGoAwayIdIncreaseFails() throws Exception {
+        EmbeddedQuicChannel parent = new EmbeddedQuicChannel();
         // Let's mark the parent as inactive before we close as otherwise we will send a close frame.
+        parent.close().get();
         EmbeddedChannel channel = newChannel(parent, new Http3ControlStreamOutboundHandler(
-                true, settingsFrame, new ChannelInboundHandlerAdapter()), false);
+                true, settingsFrame, new ChannelInboundHandlerAdapter()));
         assertTrue(channel.writeOutbound(new DefaultHttp3GoAwayFrame(4)));
         ReferenceCountUtil.release(channel.readOutbound());
 
@@ -98,11 +105,12 @@ public class Http3ControlStreamOutboundHandlerTest extends
     }
 
     @Test
-    public void testGoAwayIdUseInvalidId() {
-        QuicChannel parent = mockParent();
+    public void testGoAwayIdUseInvalidId() throws Exception {
+        EmbeddedQuicChannel parent = new EmbeddedQuicChannel();
+        parent.close().get();
         // Let's mark the parent as inactive before we close as otherwise we will send a close frame.
         EmbeddedChannel channel = newChannel(parent, new Http3ControlStreamOutboundHandler(
-                true, settingsFrame, new ChannelInboundHandlerAdapter()), false);
+                true, settingsFrame, new ChannelInboundHandlerAdapter()));
         try {
             channel.writeOutbound(new DefaultHttp3GoAwayFrame(2));
             fail();
@@ -113,18 +121,8 @@ public class Http3ControlStreamOutboundHandlerTest extends
     }
 
     @Override
-    protected EmbeddedChannel newChannel(Channel parent,
+    protected EmbeddedChannel newChannel(EmbeddedQuicChannel parent,
                                          Http3FrameTypeValidationHandler<Http3ControlStreamFrame> handler) {
-        if (parent == null) {
-            parent = Mockito.mock(QuicChannel.class);
-        }
-        return newChannel(parent, handler, false);
-    }
-
-    private EmbeddedChannel newChannel(Channel parent, Http3FrameTypeValidationHandler<Http3ControlStreamFrame> handler,
-                                       boolean parentActive) {
-        Mockito.when(parent.isActive()).thenReturn(parentActive);
-
         EmbeddedChannel channel = super.newChannel(parent, handler);
         ByteBuf buffer = channel.readOutbound();
         // Verify that we did write the control stream prefix

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamOutboundHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ControlStreamOutboundHandlerTest.java
@@ -52,16 +52,6 @@ public class Http3ControlStreamOutboundHandlerTest extends
         return Arrays.asList(Http3TestUtils.newHttp3RequestStreamFrame(), Http3TestUtils.newHttp3PushStreamFrame());
     }
 
-    @Override
-    public void testValidTypeInbound() {
-        super.testValidTypeInbound();
-    }
-
-    @Override
-    public void testValidTypeOutput() {
-        super.testValidTypeOutput();
-    }
-
     @Test
     public void testStreamClosedWhileParentStillActive() {
         EmbeddedQuicChannel parent = new EmbeddedQuicChannel();

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
@@ -37,7 +37,6 @@ import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
-
 import io.netty.util.CharsetUtil;
 import org.junit.Test;
 

--- a/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamInboundHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamInboundHandlerTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 
 public class Http3RequestStreamInboundHandlerTest {

--- a/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamValidationHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamValidationHandlerTest.java
@@ -16,13 +16,11 @@
 package io.netty.incubator.codec.http3;
 
 import io.netty.buffer.Unpooled;
-import io.netty.channel.DefaultChannelId;
-import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpMethod;
-import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.incubator.codec.quic.QuicStreamType;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -31,7 +29,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty.incubator.codec.http3.Http3TestUtils.assertException;
 import static io.netty.incubator.codec.http3.Http3TestUtils.assertFrameEquals;
-import static io.netty.incubator.codec.http3.Http3TestUtils.mockParent;
 import static io.netty.incubator.codec.http3.Http3TestUtils.verifyClose;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -52,10 +49,10 @@ public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValid
     }
 
     @Test
-    public void testInvalidFrameSequenceStartInbound() {
-        QuicChannel parent = mockParent();
-        EmbeddedChannel channel = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), true, false,
-                newHandler());
+    public void testInvalidFrameSequenceStartInbound() throws Exception {
+        EmbeddedQuicChannel parent = new EmbeddedQuicChannel();
+        final EmbeddedQuicStreamChannel channel =
+                (EmbeddedQuicStreamChannel) parent.createStream(QuicStreamType.BIDIRECTIONAL, newHandler()).get();
         Http3DataFrame dataFrame = new DefaultHttp3DataFrame(Unpooled.buffer());
         try {
             channel.writeInbound(dataFrame);
@@ -69,11 +66,11 @@ public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValid
     }
 
     @Test
-    public void testInvalidFrameSequenceEndInbound() {
-        QuicChannel parent = mockParent();
+    public void testInvalidFrameSequenceEndInbound() throws Exception {
+        EmbeddedQuicChannel parent = new EmbeddedQuicChannel();
+        final EmbeddedQuicStreamChannel channel =
+                (EmbeddedQuicStreamChannel) parent.createStream(QuicStreamType.BIDIRECTIONAL, newHandler()).get();
 
-        EmbeddedChannel channel = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), true, false,
-                newHandler());
         Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
         Http3DataFrame dataFrame = new DefaultHttp3DataFrame(Unpooled.buffer());
         Http3DataFrame dataFrame2 = new DefaultHttp3DataFrame(Unpooled.buffer());

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandlerTest.java
@@ -17,7 +17,6 @@ package io.netty.incubator.codec.http3;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.incubator.codec.quic.QuicChannel;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 
 import static org.junit.Assert.assertNotNull;
@@ -36,7 +35,7 @@ public class Http3ServerConnectionHandlerTest extends AbtractHttp3ConnectionHand
     }
 
     @Override
-    protected void assertBidirectionalStreamHandled(QuicChannel channel, QuicStreamChannel streamChannel) {
+    protected void assertBidirectionalStreamHandled(EmbeddedQuicChannel channel, QuicStreamChannel streamChannel) {
         assertNotNull(streamChannel.pipeline().context(REQUEST_HANDLER));
     }
 }

--- a/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDecoderTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDecoderTest.java
@@ -15,14 +15,13 @@
  */
 package io.netty.incubator.codec.http3;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import org.junit.Test;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.AsciiString;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class QpackEncoderDecoderTest {
     @Test

--- a/src/test/java/io/netty/incubator/codec/http3/QpackStaticTableTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackStaticTableTest.java
@@ -15,11 +15,11 @@
  */
 package io.netty.incubator.codec.http3;
 
+import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
 
 public class QpackStaticTableTest {
     @Test


### PR DESCRIPTION
__Motivation__

Today tests mock a `QuicChannel`. Over time the mocking is becoming more verbose as we require more features in http/3, eg: while adding QPACK dynamic tables, `createStream()` are required to be implemented. As `EmbeddedChannel` exists and extending it to support `QuicStreamChannel` is not much work, it is less tedious to implement and use `EmbeddedQuicChannel` instead of the mocks.

__Modification__

- Implemented `EmbeddedQuicChannel`
- Modified all usages of mocks for the `QuicChannel` to now use `EmbeddedQuicChannel`

__Result__

Less tedious changes to tests (mocks) when implementing new http/3 features.