### PR TITLE
Correctly setup and use maven repository caching

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,6 +16,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: build-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            build-cache-m2-repository-
+
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
@@ -23,7 +31,6 @@ jobs:
           key: docker-cache-build-{hash}
           restore-keys: |
             docker-cache-build-
-            docker-cache-
 
       - name: Build docker image
         run: docker-compose -f docker/docker-compose.centos-8.yaml -f docker/docker-compose.centos-8.18.yaml build

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -25,6 +25,14 @@ jobs:
 
       - uses: actions/checkout@v2
 
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: deploy-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            deploy-cache-m2-repository-
+
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -18,14 +18,11 @@ jobs:
           java-version: 8
       # Cache .m2/repository
       - uses: actions/cache@v2
-        env:
-          cache-name: verify-cache-m2-repository
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: verify-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-pr-${{ env.cache-name }}-
-            ${{ runner.os }}-pr-
+            verify-cache-m2-repository-
       - name: Verify with Maven
         run: mvn verify -B --file pom.xml -DskipTests=true -DskipH3Spec=true
 
@@ -34,6 +31,14 @@ jobs:
     needs: verify
     steps:
       - uses: actions/checkout@v2
+
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: pr-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            pr-cache-m2-repository-
 
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -44,6 +44,14 @@ jobs:
                 "password": "${{ secrets.SONATYPE_PASSWORD }}"
             }]
 
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: release-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            release-cache-m2-repository-
+
       - name: Prepare release with Maven
         run:  mvn -B --file pom.xml release:prepare -DpreparationGoals=clean -DskipTests=true -DskipH3Spec=true
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,14 +40,11 @@ jobs:
 
     # Cache .m2/repository
     - uses: actions/cache@v2
-      env:
-        cache-name: ${{ matrix.language }}-cache-m2-repository
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-analyze-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+        key: ${{ matrix.language }}-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-analyze-${{ env.cache-name }}-
-          ${{ runner.os }}-analyze-
+          ${{ matrix.language }}-cache-m2-repository-
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/docker/Dockerfile.centos8
+++ b/docker/Dockerfile.centos8
@@ -25,11 +25,3 @@ RUN echo 'PATH=/jdk/bin:$PATH' >> ~/.bashrc
 WORKDIR /opt
 RUN curl https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar -xz
 RUN echo 'PATH=/opt/apache-maven-3.6.3/bin/:$PATH' >> ~/.bashrc
-
-# Prepare our own build
-ENV PATH /opt/apache-maven-3.6.3/bin/:$PATH
-ENV JAVA_HOME /jdk/
-
-COPY ./pom.xml $SOURCE_DIR/pom.xml
-WORKDIR $SOURCE_DIR
-RUN /bin/bash -c 'source $HOME/.bashrc && mvn dependency:go-offline surefire:test -ntp'

--- a/docker/docker-compose.centos-8.yaml
+++ b/docker/docker-compose.centos-8.yaml
@@ -14,6 +14,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh:delegated
       - ~/.gnupg:/root/.gnupg:delegated
+      - ~/.m2/repository:/root/.m2/repository
       - ..:/code:delegated
     working_dir: /code
 
@@ -31,6 +32,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ..:/code
 


### PR DESCRIPTION
Motivation:

To make the build more stable we should cache the maven artifacts

Modifications:

- Adjust workflows to use caching
- Adjust docker / docker-compose config to use the cached .m2/repository

Result:

More stable builds