### PR TITLE
Update to latest netty-incubator-codec-quic and netty-incubator-h3spe…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <skipTests>false</skipTests>
     <netty.version>4.1.63.Final</netty.version>
     <netty.build.version>29</netty.build.version>
-    <netty.quic.version>0.0.10.Final</netty.quic.version>
+    <netty.quic.version>0.0.11.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <release.gpg.keyname />
     <release.gpg.passphrase />
@@ -303,7 +303,7 @@
       <plugin>
         <groupId>io.netty.incubator</groupId>
         <artifactId>netty-incubator-h3spec-maven-plugin</artifactId>
-        <version>0.0.4.Final</version>
+        <version>0.0.5.Final</version>
         <configuration>
           <delay>1000</delay>
           <mainClass>io.netty.incubator.codec.http3.example.Http3ServerExample</mainClass>

--- a/src/main/java/io/netty/incubator/codec/http3/Http3.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3.java
@@ -38,7 +38,8 @@ public final class Http3 {
             "h3-29",
             "h3-30",
             "h3-31",
-            "h3-32"
+            "h3-32",
+            "h3"
     };
 
     private static final AttributeKey<QuicStreamChannel> HTTP3_CONTROL_STREAM_KEY =


### PR DESCRIPTION
…c-maven-plugin

Motivation:

A new release of netty-incubator-codec-quic and netty-incubator-h3spec-maven-plugin is out.

Modifications:

- update netty-incubator-codec-quic to 0.0.11.Final
- update netty-incubator-h3spec-maven-plugin to 0.0.5.Final
- update ALPN to use h3

Result:

Use latest releases