### PR TITLE
Add ci profile which should be used when running workflows

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -24,7 +24,7 @@ jobs:
           restore-keys: |
             verify-cache-m2-repository-
       - name: Verify with Maven
-        run: mvn verify -B --file pom.xml -DskipTests=true -DskipH3Spec=true
+        run: mvn -Pci -B --file pom.xml verify -DskipTests=true -DskipH3Spec=true
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -53,10 +53,10 @@ jobs:
             release-cache-m2-repository-
 
       - name: Prepare release with Maven
-        run:  mvn -B --file pom.xml release:prepare -DpreparationGoals=clean -DskipTests=true -DskipH3Spec=true
+        run:  mvn -Pci -B --file pom.xml release:prepare -DpreparationGoals=clean -DskipTests=true -DskipH3Spec=true
 
       - name: Perform release with Maven
-        run: mvn -B --file pom.xml release:perform -Drelease.gpg.keyname=${{ secrets.GPG_KEYNAME }} -Drelease.gpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
+        run: mvn -Pci -B --file pom.xml release:perform -Drelease.gpg.keyname=${{ secrets.GPG_KEYNAME }} -Drelease.gpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
 
       - name: Rollback release on failure
         if: ${{ failure() }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -57,7 +57,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Build project
-      run: ./mvnw clean package -DskipTests=true -DskipH3Spec=true
+      run: ./mvnw -Pci clean package -DskipTests=true -DskipH3Spec=true
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/docker/docker-compose.centos-8.yaml
+++ b/docker/docker-compose.centos-8.yaml
@@ -20,15 +20,15 @@ services:
 
   build:
     <<: *common
-    command: /bin/bash -cl "mvn clean package"
+    command: /bin/bash -cl "mvn -Pci clean package"
 
   build-leak:
     <<: *common
-    command: /bin/bash -cl "mvn -Pleak clean package"
+    command: /bin/bash -cl "mvn -Pci,leak clean package"
 
   deploy:
     <<: *common
-    command: /bin/bash -cl "mvn clean deploy -DskipTests=true"
+    command: /bin/bash -cl "mvn -Pci clean deploy -DskipTests=true"
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,14 @@
 
   <profiles>
     <profile>
+      <id>ci</id>
+      <properties>
+        <http.keepAlive>false</http.keepAlive>
+        <maven.wagon.http.pool>false</maven.wagon.http.pool>
+        <maven.wagon.httpconnectionManager.ttlSeconds>120</maven.wagon.httpconnectionManager.ttlSeconds>
+      </properties>
+    </profile>
+    <profile>
       <id>leak</id>
       <properties>
         <test.argLine>-Dio.netty.leakDetectionLevel=paranoid -Dio.netty.leakDetection.targetRecords=32</test.argLine>


### PR DESCRIPTION
Motivation:

It seems like it is a known issue that maven frequently sees connection reset / connection timeout during CI builds. We should workaround these issues like others did:

See https://github.com/kiegroup/kie-wb-common/pull/3416

Modifications:

Add extra maven options during build to reduce the likelyness of timeouts / resets.

Result:

More stable builds