### PR TITLE
Use MAVEN_OPTS to setup timeouts for dependency downloads

### DIFF
--- a/.github/scripts/release_rollback.sh
+++ b/.github/scripts/release_rollback.sh
@@ -7,5 +7,5 @@ if [ "$#" -ne 1 ]; then
 fi
 
 TAG=$(grep scm.tag= "$1" | cut -d'=' -f2)
-mvn -B --file pom.xml release:rollback
+./mvnw -B --file pom.xml release:rollback
 git push origin :"$TAG"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,6 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -10,6 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pr-reports.yml
+++ b/.github/workflows/ci-pr-reports.yml
@@ -4,6 +4,10 @@ on:
     workflows: [ "Build PR" ]
     types:
       - completed
+
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -7,6 +7,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   verify:
     runs-on: ubuntu-18.04
@@ -24,7 +27,7 @@ jobs:
           restore-keys: |
             verify-cache-m2-repository-
       - name: Verify with Maven
-        run: mvn -Pci -B --file pom.xml verify -DskipTests=true -DskipH3Spec=true
+        run: ./mvnw -B --file pom.xml verify -DskipTests=true -DskipH3Spec=true
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -4,6 +4,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -53,10 +56,10 @@ jobs:
             release-cache-m2-repository-
 
       - name: Prepare release with Maven
-        run:  mvn -Pci -B --file pom.xml release:prepare -DpreparationGoals=clean -DskipTests=true -DskipH3Spec=true
+        run: ./mvnw -B --file pom.xml release:prepare -DpreparationGoals=clean -DskipTests=true -DskipH3Spec=true
 
       - name: Perform release with Maven
-        run: mvn -Pci -B --file pom.xml release:perform -Drelease.gpg.keyname=${{ secrets.GPG_KEYNAME }} -Drelease.gpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
+        run: ./mvnw -B --file pom.xml release:perform -Drelease.gpg.keyname=${{ secrets.GPG_KEYNAME }} -Drelease.gpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
 
       - name: Rollback release on failure
         if: ${{ failure() }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,9 @@ on:
   schedule:
     - cron: '40 9 * * 1'
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   analyze:
     name: Analyze
@@ -57,7 +60,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Build project
-      run: ./mvnw -Pci clean package -DskipTests=true -DskipH3Spec=true
+      run: ./mvnw clean package -DskipTests=true -DskipH3Spec=true
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,9 +1,0 @@
-<settings>
-  <servers>
-    <server>
-      <id>sonatype-nexus-snapshots</id>
-      <username>${env.SANOTYPE_USER}</username>
-      <password>${env.SANOTYPE_PASSWORD}</password>
-    </server>
-  </servers>
-</settings>

--- a/docker/docker-compose.centos-8.yaml
+++ b/docker/docker-compose.centos-8.yaml
@@ -11,6 +11,11 @@ services:
   common: &common
     image: netty-codec-http3-centos8:default
     depends_on: [runtime-setup]
+    environment:
+      - GPG_KEYNAME
+      - GPG_PASSPHRASE
+      - GPG_PRIVATE_KEY
+      - MAVEN_OPTS
     volumes:
       - ~/.ssh:/root/.ssh:delegated
       - ~/.gnupg:/root/.gnupg:delegated
@@ -20,15 +25,15 @@ services:
 
   build:
     <<: *common
-    command: /bin/bash -cl "mvn -Pci clean package"
+    command: /bin/bash -cl "./mvnw clean package"
 
   build-leak:
     <<: *common
-    command: /bin/bash -cl "mvn -Pci,leak clean package"
+    command: /bin/bash -cl "./mvnw -Pleak clean package"
 
   deploy:
     <<: *common
-    command: /bin/bash -cl "mvn -Pci clean deploy -DskipTests=true"
+    command: /bin/bash -cl "./mvnw clean deploy -DskipTests=true"
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
@@ -38,9 +43,6 @@ services:
 
   shell:
     <<: *common
-    environment:
-      - SONATYPE_USER
-      - SONATYPE_PASSWORD
     volumes:
       - ~/.ssh:/root/.ssh:delegated
       - ~/.gnupg:/root/.gnupg:delegated

--- a/pom.xml
+++ b/pom.xml
@@ -328,14 +328,6 @@
 
   <profiles>
     <profile>
-      <id>ci</id>
-      <properties>
-        <http.keepAlive>false</http.keepAlive>
-        <maven.wagon.http.pool>false</maven.wagon.http.pool>
-        <maven.wagon.httpconnectionManager.ttlSeconds>120</maven.wagon.httpconnectionManager.ttlSeconds>
-      </properties>
-    </profile>
-    <profile>
       <id>leak</id>
       <properties>
         <test.argLine>-Dio.netty.leakDetectionLevel=paranoid -Dio.netty.leakDetection.targetRecords=32</test.argLine>


### PR DESCRIPTION
Motivation:

Just use MAVEN_OPTS to setup all the timeouts etc for dependency downloads. This way we at least can be sure these are applied.

Modifications:

- Use MAVEN_OPTS
- Remove ci profile
- Remove unused settings.xml file
- Always use ./mvnw

Result:

Build stability improvements