### PR TITLE
Upgrade netty and netty-incubator-codec-quic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
   <properties>
     <javaModuleName>io.netty.incubator.codec.http3</javaModuleName>
     <skipTests>false</skipTests>
-    <netty.version>4.1.64.Final</netty.version>
+    <netty.version>4.1.65.Final</netty.version>
     <netty.build.version>29</netty.build.version>
-    <netty.quic.version>0.0.12.Final</netty.quic.version>
+    <netty.quic.version>0.0.13.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <release.gpg.keyname />
     <release.gpg.passphrase />

--- a/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicChannel.java
+++ b/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicChannel.java
@@ -36,6 +36,7 @@ import io.netty.incubator.codec.quic.QuicStreamType;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
+import javax.net.ssl.SSLEngine;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.Map;
@@ -62,6 +63,11 @@ final class EmbeddedQuicChannel extends EmbeddedChannel implements QuicChannel {
     EmbeddedQuicChannel(Channel parent, ChannelId channelId, boolean register, boolean hasDisconnect,
                         ChannelHandler... handlers) {
         super(parent, channelId, register, hasDisconnect, handlers);
+    }
+
+    @Override
+    public SSLEngine sslEngine() {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

We did release netty and netty-incubator-codec-quic. Let's update

Modifications:

- Update to netty 4.1.65.Final
- Update to netty-incubator-codec-quic 0.0.13.Final

Result:

Use latest releases