### PR TITLE
Upgrade netty and netty quic dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
   <properties>
     <javaModuleName>io.netty.incubator.codec.http3</javaModuleName>
     <skipTests>false</skipTests>
-    <netty.version>4.1.65.Final</netty.version>
+    <netty.version>4.1.66.Final</netty.version>
     <netty.build.version>29</netty.build.version>
-    <netty.quic.version>0.0.16.Final</netty.quic.version>
+    <netty.quic.version>0.0.17.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <release.gpg.keyname />
     <release.gpg.passphrase />


### PR DESCRIPTION
Motivation:

We should depend on the latest releases

Modifications:

- Upgrade netty to 4.1.66.Final
- Upgrade netty-incubator-codec-quic to 0.0.17.Final

Result:

Use latest versions