### PR TITLE
Set QpackAttributes in `handlerAdded()`

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3ConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ConnectionHandler.java
@@ -81,7 +81,6 @@ public abstract class Http3ConnectionHandler extends ChannelInboundHandlerAdapte
         if (!controlStreamCreationInProgress && Http3.getLocalControlStream(ctx.channel()) == null) {
             controlStreamCreationInProgress = true;
             QuicChannel channel = (QuicChannel) ctx.channel();
-            Http3.setQpackAttributes(channel, new QpackAttributes(channel, disableQpackDynamicTable));
             // Once the channel became active we need to create an unidirectional stream and write the
             // Http3SettingsFrame to it. This needs to be the first frame on this stream.
             // https://tools.ietf.org/html/draft-ietf-quic-http-32#section-6.2.1.
@@ -141,6 +140,8 @@ public abstract class Http3ConnectionHandler extends ChannelInboundHandlerAdapte
 
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) {
+        QuicChannel channel = (QuicChannel) ctx.channel();
+        Http3.setQpackAttributes(channel, new QpackAttributes(channel, disableQpackDynamicTable));
         if (ctx.channel().isActive()) {
             createControlStreamIfNeeded(ctx);
         }


### PR DESCRIPTION
__Motivation__

As reported by #157; `Http3ConnectionHandler` sets `QpackAttributes` on the channel when the channel is active, but `Http3FrameCodec` requires it in `handlerAdded()` raising an exception if a stream is created before the `channelActive` is fired on the parent channel. This can happen if the stream is created from within the listener of the connect future.

__Modification__

As `QpackAttributes` do not require the channel to be active, we now create it in `handlerAdded()` unconditionally, so that it is consistent with the expectations of `Http3FrameCodec`.

__Result__

Fixes #157