### PR TITLE
Remove `Http3ServerPushStreamManager` usage from example

### DIFF
--- a/src/test/java/io/netty/incubator/codec/http3/example/Http3ServerExample.java
+++ b/src/test/java/io/netty/incubator/codec/http3/example/Http3ServerExample.java
@@ -31,7 +31,6 @@ import io.netty.incubator.codec.http3.Http3DataFrame;
 import io.netty.incubator.codec.http3.Http3HeadersFrame;
 import io.netty.incubator.codec.http3.Http3RequestStreamInboundHandler;
 import io.netty.incubator.codec.http3.Http3ServerConnectionHandler;
-import io.netty.incubator.codec.http3.Http3ServerPushStreamManager;
 import io.netty.incubator.codec.quic.InsecureQuicTokenHandler;
 import io.netty.incubator.codec.quic.QuicChannel;
 import io.netty.incubator.codec.quic.QuicSslContext;
@@ -73,7 +72,6 @@ public final class Http3ServerExample {
                     @Override
                     protected void initChannel(QuicChannel ch) {
                         // Called for each connection
-                        Http3ServerPushStreamManager pushStreamManager = new Http3ServerPushStreamManager(ch);
                         ch.pipeline().addLast(new Http3ServerConnectionHandler(
                                 new ChannelInitializer<QuicStreamChannel>() {
                                     // Called for each request-stream,
@@ -111,7 +109,7 @@ public final class Http3ServerExample {
                                             }
                                         });
                                     }
-                                }, pushStreamManager.controlStreamListener(), null, null, false));
+                                }));
                     }
                 }).build();
         try {


### PR DESCRIPTION
__Motivation__

Push streams are more of an advanced feature and makes the example more complex.

__Modification__

Removed the usage of `Http3ServerPushStreamManager` from `Http3ServerExample`

__Result__

Simplify example code