### PR TITLE
Use sdkman for JDK installation

### DIFF
--- a/docker/Dockerfile.centos8
+++ b/docker/Dockerfile.centos8
@@ -9,18 +9,26 @@ RUN yum install -y \
  gnupg \
  tar \
  unzip \
- wget
+ wget \
+ zip
 
 RUN mkdir $SOURCE_DIR
 WORKDIR $SOURCE_DIR
 
-ARG java_version=1.8
-ENV JAVA_VERSION $java_version
-# installing java with jabba
-RUN curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | JABBA_COMMAND="install $JAVA_VERSION -o /jdk" bash
+# Downloading and installing SDKMAN!
+RUN curl -s "https://get.sdkman.io" | bash
 
-RUN echo 'export JAVA_HOME="/jdk"' >> ~/.bashrc
-RUN echo 'PATH=/jdk/bin:$PATH' >> ~/.bashrc
+ARG java_version="8.0.302-zulu"
+ENV JAVA_VERSION $java_version
+
+# Installing Java removing some unnecessary SDKMAN files
+RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
+    yes | sdk install java $JAVA_VERSION && \
+    rm -rf $HOME/.sdkman/archives/* && \
+    rm -rf $HOME/.sdkman/tmp/*"
+
+RUN echo 'export JAVA_HOME="/root/.sdkman/candidates/java/current"' >> ~/.bashrc
+RUN echo 'PATH=$JAVA_HOME/bin:$PATH' >> ~/.bashrc
 
 WORKDIR /opt
 RUN curl https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar -xz

--- a/docker/docker-compose.centos-8.18.yaml
+++ b/docker/docker-compose.centos-8.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-http3-centos8:centos-8-1.8
     build:
       args:
-        java_version : "adopt@1.8.0-292"
+        java_version : "8.0.302-zulu"
 
   build:
     image: netty-codec-http3-centos8:centos-8-1.8


### PR DESCRIPTION
Motivation:

jabba is not updated anymore, let's use sdkman for JDK installation

Modifications:

- Switch to sdkman
- Update to latest JDK8 release

Result:

Be able to use latest JDK version again