### PR TITLE
Use google mirror for maven distribution

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://downloads.apache.org/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.zip
+distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip


### PR DESCRIPTION
Following what was done for netty in https://github.com/netty/netty/pull/11689