### PR TITLE
Update netty, netty-incubator-codec-quic and netty-build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
   <properties>
     <javaModuleName>io.netty.incubator.codec.http3</javaModuleName>
     <skipTests>false</skipTests>
-    <netty.version>4.1.69.Final</netty.version>
-    <netty.build.version>29</netty.build.version>
-    <netty.quic.version>0.0.19.Final</netty.quic.version>
+    <netty.version>4.1.70.Final</netty.version>
+    <netty.build.version>30</netty.build.version>
+    <netty.quic.version>0.0.20.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <release.gpg.keyname />
     <release.gpg.passphrase />


### PR DESCRIPTION
Motivation:

There were new releases of netty, netty-incubator-codec-quic and netty-build

Modifications:

- Update netty to 4.1.70.Final
- Update netty-incubator-codec-quic to 0.0.20.Final
- Update netty-build to 30

Result:

Use latest releases