### PR TITLE
Move tests to junit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <netty.build.version>30</netty.build.version>
     <netty.quic.version>0.0.25.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
+    <junit.version>5.8.2</junit.version>
     <release.gpg.keyname />
     <release.gpg.passphrase />
     <test.argLine>-D_</test.argLine>
@@ -374,9 +375,21 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/io/netty/incubator/codec/http3/AbtractHttp3ConnectionHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/AbtractHttp3ConnectionHandlerTest.java
@@ -19,10 +19,10 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.incubator.codec.quic.QuicStreamType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbtractHttp3ConnectionHandlerTest {
 

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
@@ -38,14 +38,15 @@ import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Http3FrameToHttpObjectCodecTest {
 
@@ -75,15 +76,12 @@ public class Http3FrameToHttpObjectCodecTest {
         assertFalse(ch.finish());
     }
 
-    @Test (expected = EncoderException.class)
+    @Test
     public void encodeNonFullHttpResponse100ContinueIsRejected() {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
-        try {
-            ch.writeOutbound(new DefaultHttpResponse(
-                    HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE));
-        } finally {
-            ch.finishAndReleaseAll();
-        }
+        assertThrows(EncoderException.class, () -> ch.writeOutbound(new DefaultHttpResponse(
+                HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE)));
+        ch.finishAndReleaseAll();
     }
 
     @Test

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameTypeValidationHandlerTest.java
@@ -25,12 +25,12 @@ import java.util.List;
 abstract class Http3FrameTypeValidationHandlerTest extends
         AbstractHttp3FrameTypeValidationHandlerTest<Http3RequestStreamFrame> {
 
-    Http3FrameTypeValidationHandlerTest(boolean isOutbound, boolean isInbound) {
-        super(true, QuicStreamType.BIDIRECTIONAL);
+    Http3FrameTypeValidationHandlerTest(boolean isInbound, boolean isOutbound) {
+        super(QuicStreamType.BIDIRECTIONAL, isInbound, isOutbound);
     }
 
     @Override
-    protected ChannelHandler newHandler() {
+    protected ChannelHandler newHandler(boolean server) {
         return new Http3FrameTypeDuplexValidationHandler<>(Http3RequestStreamFrame.class);
     }
 

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameTypeValidatorTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameTypeValidatorTest.java
@@ -15,8 +15,9 @@
  */
 package io.netty.incubator.codec.http3;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class Http3FrameTypeValidatorTest {
 
@@ -35,12 +36,7 @@ public abstract class Http3FrameTypeValidatorTest {
     @Test
     public void testInvalidFrameTypes() {
         for (long invalidFrameType: invalidFramesTypes()) {
-            try {
-                newValidator().validate(invalidFrameType, true);
-                Assert.fail("Expected failure for frame type: " + invalidFrameType);
-            } catch (Http3Exception expected) {
-                // ignore
-            }
+            assertThrows(Http3Exception.class, () -> newValidator().validate(invalidFrameType, true));
         }
     }
 }

--- a/src/test/java/io/netty/incubator/codec/http3/Http3HeadersSinkTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3HeadersSinkTest.java
@@ -15,8 +15,10 @@
  */
 package io.netty.incubator.codec.http3;
 
-import org.junit.Assert;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Http3HeadersSinkTest {
 
@@ -24,12 +26,9 @@ public class Http3HeadersSinkTest {
     public void testHeaderSizeExceeded() {
         Http3HeadersSink sink = new Http3HeadersSink(new DefaultHttp3Headers(), 32, false, false);
         addMandatoryPseudoHeaders(sink, false);
-        try {
-            sink.finish();
-            Assert.fail();
-        } catch (Http3Exception e) {
-            Http3TestUtils.assertException(Http3ErrorCode.H3_EXCESSIVE_LOAD, e);
-        }
+
+        Http3Exception e = assertThrows(Http3Exception.class, () -> sink.finish());
+        Http3TestUtils.assertException(Http3ErrorCode.H3_EXCESSIVE_LOAD, e);
     }
 
     @Test
@@ -40,27 +39,27 @@ public class Http3HeadersSinkTest {
         sink.finish();
     }
 
-    @Test(expected = Http3HeadersValidationException.class)
-    public void testPseudoHeaderFollowsNormalHeader() throws Exception {
+    @Test
+    public void testPseudoHeaderFollowsNormalHeader() {
         Http3HeadersSink sink = new Http3HeadersSink(new DefaultHttp3Headers(), 512, true, false);
         sink.accept("name", "value");
         sink.accept(Http3Headers.PseudoHeaderName.AUTHORITY.value(), "value");
-        sink.finish();
+        assertThrows(Http3HeadersValidationException.class, () -> sink.finish());
     }
 
-    @Test(expected = Http3HeadersValidationException.class)
-    public void testInvalidatePseudoHeader() throws Exception {
+    @Test
+    public void testInvalidatePseudoHeader() {
         Http3HeadersSink sink = new Http3HeadersSink(new DefaultHttp3Headers(), 512, true, false);
         sink.accept(":invalid", "value");
-        sink.finish();
+        assertThrows(Http3HeadersValidationException.class, () -> sink.finish());
     }
 
-    @Test(expected = Http3HeadersValidationException.class)
-    public void testMixRequestResponsePseudoHeaders() throws Exception {
+    @Test
+    public void testMixRequestResponsePseudoHeaders() {
         Http3HeadersSink sink = new Http3HeadersSink(new DefaultHttp3Headers(), 512, true, false);
         sink.accept(Http3Headers.PseudoHeaderName.METHOD.value(), "value");
         sink.accept(Http3Headers.PseudoHeaderName.STATUS.value(), "value");
-        sink.finish();
+        assertThrows(Http3HeadersValidationException.class, () -> sink.finish());
     }
 
     @Test
@@ -79,37 +78,37 @@ public class Http3HeadersSinkTest {
         sink.finish();
     }
 
-    @Test(expected = Http3HeadersValidationException.class)
-    public void testDuplicatePseudoHeader() throws Http3Exception {
+    @Test
+    public void testDuplicatePseudoHeader() {
         Http3HeadersSink sink = new Http3HeadersSink(new DefaultHttp3Headers(), 512, true, false);
         addMandatoryPseudoHeaders(sink, false);
         sink.accept(Http3Headers.PseudoHeaderName.AUTHORITY.value(), "value");
-        sink.finish();
+        assertThrows(Http3HeadersValidationException.class, () -> sink.finish());
     }
 
-    @Test(expected = Http3HeadersValidationException.class)
-    public void testMandatoryPseudoHeaderMissingRequest() throws Http3Exception {
+    @Test
+    public void testMandatoryPseudoHeaderMissingRequest() {
         Http3HeadersSink sink = new Http3HeadersSink(new DefaultHttp3Headers(), 512, true, false);
         sink.accept(Http3Headers.PseudoHeaderName.METHOD.value(), "GET");
         sink.accept(Http3Headers.PseudoHeaderName.PATH.value(), "/");
         sink.accept(Http3Headers.PseudoHeaderName.SCHEME.value(), "https");
-        sink.finish();
+        assertThrows(Http3HeadersValidationException.class, () -> sink.finish());
     }
 
-    @Test(expected = Http3HeadersValidationException.class)
-    public void testMandatoryPseudoHeaderMissingResponse() throws Http3Exception {
+    @Test
+    public void testMandatoryPseudoHeaderMissingResponse() {
         Http3HeadersSink sink = new Http3HeadersSink(new DefaultHttp3Headers(), 512, true, false);
-        sink.finish();
+        assertThrows(Http3HeadersValidationException.class, () -> sink.finish());
     }
 
-    @Test(expected = Http3HeadersValidationException.class)
-    public void testInvalidPseudoHeadersForConnect() throws Exception {
+    @Test
+    public void testInvalidPseudoHeadersForConnect() {
         Http3HeadersSink sink = new Http3HeadersSink(new DefaultHttp3Headers(), 512, true, false);
         sink.accept(Http3Headers.PseudoHeaderName.METHOD.value(), "CONNECT");
         sink.accept(Http3Headers.PseudoHeaderName.PATH.value(), "/");
         sink.accept(Http3Headers.PseudoHeaderName.SCHEME.value(), "https");
         sink.accept(Http3Headers.PseudoHeaderName.AUTHORITY.value(), "value");
-        sink.finish();
+        assertThrows(Http3HeadersValidationException.class, () -> sink.finish());
     }
 
     @Test
@@ -120,18 +119,18 @@ public class Http3HeadersSinkTest {
         sink.finish();
     }
 
-    @Test(expected = Http3HeadersValidationException.class)
-    public void testTrailersWithRequestPseudoHeaders() throws Exception {
+    @Test
+    public void testTrailersWithRequestPseudoHeaders() {
         Http3HeadersSink sink = new Http3HeadersSink(new DefaultHttp3Headers(), 512, true, true);
         sink.accept(Http3Headers.PseudoHeaderName.METHOD.value(), "CONNECT");
-        sink.finish();
+        assertThrows(Http3HeadersValidationException.class, () -> sink.finish());
     }
 
-    @Test(expected = Http3HeadersValidationException.class)
-    public void testTrailersWithResponsePseudoHeaders() throws Exception {
+    @Test
+    public void testTrailersWithResponsePseudoHeaders() {
         Http3HeadersSink sink = new Http3HeadersSink(new DefaultHttp3Headers(), 512, true, true);
         sink.accept(Http3Headers.PseudoHeaderName.STATUS.value(), "200");
-        sink.finish();
+        assertThrows(Http3HeadersValidationException.class, () -> sink.finish());
     }
 
     private static void addMandatoryPseudoHeaders(Http3HeadersSink sink, boolean req) {

--- a/src/test/java/io/netty/incubator/codec/http3/Http3PushStreamServerValidationHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3PushStreamServerValidationHandlerTest.java
@@ -26,11 +26,11 @@ public class Http3PushStreamServerValidationHandlerTest extends
         AbstractHttp3FrameTypeValidationHandlerTest<Http3PushStreamFrame> {
 
     public Http3PushStreamServerValidationHandlerTest() {
-        super(true, QuicStreamType.UNIDIRECTIONAL);
+        super(QuicStreamType.UNIDIRECTIONAL, false, true);
     }
 
     @Override
-    protected ChannelHandler newHandler() {
+    protected ChannelHandler newHandler(boolean server) {
         return Http3PushStreamServerValidationHandler.INSTANCE;
     }
 

--- a/src/test/java/io/netty/incubator/codec/http3/Http3PushStreamTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3PushStreamTest.java
@@ -21,9 +21,9 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 
@@ -32,10 +32,10 @@ import static io.netty.incubator.codec.http3.Http3ErrorCode.H3_ID_ERROR;
 import static io.netty.incubator.codec.http3.Http3TestUtils.assertFrameEquals;
 import static io.netty.incubator.codec.http3.Http3TestUtils.verifyClose;
 import static io.netty.incubator.codec.quic.QuicStreamType.UNIDIRECTIONAL;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -50,7 +50,7 @@ public class Http3PushStreamTest {
     private EmbeddedQuicStreamChannel serverLocalControlStream;
     private EmbeddedQuicStreamChannel clientLocalControlStream;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         serverConnectionHandler = new Http3ServerConnectionHandler(new ChannelDuplexHandler(), null, null, null, true);
         serverChannel = new EmbeddedQuicChannel(true, serverConnectionHandler);
@@ -84,7 +84,7 @@ public class Http3PushStreamTest {
         assertTrue(clientLocalControlStream.releaseOutbound());
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         assertFalse(serverLocalControlStream.finish());
         assertFalse(serverChannel.finish());

--- a/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamInboundHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamInboundHandlerTest.java
@@ -20,13 +20,12 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Http3RequestStreamInboundHandlerTest {
 

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandlerTest.java
@@ -19,7 +19,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class Http3ServerConnectionHandlerTest extends AbtractHttp3ConnectionHandlerTest {
     private static final ChannelHandler REQUEST_HANDLER = new ChannelInboundHandlerAdapter() {

--- a/src/test/java/io/netty/incubator/codec/http3/Http3ServerPushStreamManagerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ServerPushStreamManagerTest.java
@@ -24,9 +24,9 @@ import io.netty.channel.ChannelPromise;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Promise;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,11 +34,12 @@ import java.util.concurrent.Callable;
 
 import static io.netty.incubator.codec.http3.Http3TestUtils.newHeadersFrameWithPseudoHeaders;
 import static java.util.function.UnaryOperator.identity;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -50,7 +51,7 @@ public class Http3ServerPushStreamManagerTest {
     private ChannelHandlerContext controlStreamHandlerCtx;
     private EmbeddedQuicStreamChannel localControlStream;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         connectionHandler = new Http3ServerConnectionHandler(new Http3RequestStreamInboundHandler() {
             @Override
@@ -75,7 +76,7 @@ public class Http3ServerPushStreamManagerTest {
         manager = new Http3ServerPushStreamManager(channel);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         assertFalse(localControlStream.finish());
         assertFalse(channel.finish());

--- a/src/test/java/io/netty/incubator/codec/http3/Http3TestUtils.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3TestUtils.java
@@ -21,8 +21,8 @@ import io.netty.util.ReferenceCounted;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 final class Http3TestUtils {
 
@@ -35,8 +35,8 @@ final class Http3TestUtils {
     }
 
     static void verifyClose(int times, Http3ErrorCode expectedCode, EmbeddedQuicChannel channel) {
-        assertEquals("Close not invoked with expected times with error code: " + expectedCode.code, times,
-                channel.closeErrorCodes().stream().filter(integer -> integer == expectedCode.code).count());
+        assertEquals(times, channel.closeErrorCodes().stream().filter(integer -> integer == expectedCode.code).count(),
+                "Close not invoked with expected times with error code: " + expectedCode.code);
     }
 
     static void verifyClose(Http3ErrorCode expectedCode, EmbeddedQuicChannel channel) {

--- a/src/test/java/io/netty/incubator/codec/http3/HttpConversionUtilTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/HttpConversionUtilTest.java
@@ -21,7 +21,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.AsciiString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
 import static io.netty.handler.codec.http.HttpHeaderNames.COOKIE;
@@ -33,12 +33,13 @@ import static io.netty.handler.codec.http.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.netty.handler.codec.http.HttpHeaderNames.UPGRADE;
 import static io.netty.handler.codec.http.HttpHeaderValues.GZIP;
 import static io.netty.handler.codec.http.HttpHeaderValues.TRAILERS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HttpConversionUtilTest {
 
@@ -84,9 +85,10 @@ public class HttpConversionUtilTest {
         assertSame(AsciiString.EMPTY_STRING, headers.authority());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setHttp2AuthorityWithEmptyAuthority() {
-        HttpConversionUtil.setHttp3Authority("info@", new DefaultHttp3Headers());
+        assertThrows(IllegalArgumentException.class,
+                () -> HttpConversionUtil.setHttp3Authority("info@", new DefaultHttp3Headers()));
     }
 
     @Test

--- a/src/test/java/io/netty/incubator/codec/http3/QpackDecoderDynamicTableTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackDecoderDynamicTableTest.java
@@ -16,9 +16,11 @@
 
 package io.netty.incubator.codec.http3;
 
-import org.junit.Test;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class QpackDecoderDynamicTableTest {
 
@@ -52,18 +54,15 @@ public class QpackDecoderDynamicTableTest {
         table.add(entry);
         assertEquals(entry, table.getEntry(0));
         table.clear();
-        try {
-            table.getEntry(0);
-            fail();
-        } catch (QpackException e) {
-            //success
-        }
+
+        assertThrows(QpackException.class, () -> table.getEntry(0));
     }
 
-    @Test(expected = QpackException.class)
+    @Test
     public void getEntryExceptionally() throws Exception {
         QpackDecoderDynamicTable table = newTable(1);
-        table.getEntry(0);
+
+        assertThrows(QpackException.class, () -> table.getEntry(0));
     }
 
     @Test

--- a/src/test/java/io/netty/incubator/codec/http3/QpackDecoderHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackDecoderHandlerTest.java
@@ -17,8 +17,8 @@ package io.netty.incubator.codec.http3;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.incubator.codec.quic.QuicStreamType;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 
@@ -30,8 +30,8 @@ import static java.lang.Math.floorDiv;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class QpackDecoderHandlerTest {
     private static final QpackHeaderField fooBar = new QpackHeaderField("foo", "bar");
@@ -43,7 +43,7 @@ public class QpackDecoderHandlerTest {
     private int maxEntries;
     private QpackAttributes attributes;
 
-    @After
+    @AfterEach
     public void tearDown() {
         assertFalse(encoderStream.finish());
         assertFalse(decoderStream.finish());
@@ -54,13 +54,9 @@ public class QpackDecoderHandlerTest {
         setup(128L);
         encodeHeaders(headers -> headers.add(fooBar.name, fooBar.value));
 
-        try {
-            sendAckForStreamId(decoderStream.streamId());
-            fail();
-        } catch (Http3Exception e) {
-            // expected
-            assertThat(e.getCause(), instanceOf(QpackException.class));
-        }
+        Http3Exception e = assertThrows(Http3Exception.class, () -> sendAckForStreamId(decoderStream.streamId()));
+        assertThat(e.getCause(), instanceOf(QpackException.class));
+
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
         finishStreams();
     }
@@ -86,13 +82,10 @@ public class QpackDecoderHandlerTest {
     @Test
     public void sectionAckUnknownStream() throws Exception {
         setup(128);
-        try {
-            sendAckForStreamId(1);
-            fail();
-        } catch (Http3Exception e) {
-            // exepected
-            assertThat(e.getCause(), instanceOf(QpackException.class));
-        }
+
+        Http3Exception e = assertThrows(Http3Exception.class, () -> sendAckForStreamId(1));
+        assertThat(e.getCause(), instanceOf(QpackException.class));
+
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
         finishStreams();
     }
@@ -106,13 +99,8 @@ public class QpackDecoderHandlerTest {
         encodeHeaders(headers -> headers.add(fooBar.name, fooBar.value));
         sendAckForStreamId(decoderStream.streamId());
 
-        try {
-            sendAckForStreamId(decoderStream.streamId());
-            fail();
-        } catch (Http3Exception e) {
-            // expected
-            assertThat(e.getCause(), instanceOf(QpackException.class));
-        }
+        Http3Exception e = assertThrows(Http3Exception.class, () -> sendAckForStreamId(decoderStream.streamId()));
+        assertThat(e.getCause(), instanceOf(QpackException.class));
 
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
         finishStreams();
@@ -167,13 +155,9 @@ public class QpackDecoderHandlerTest {
 
         sendStreamCancellation(decoderStream.streamId());
 
-        try {
-            sendAckForStreamId(decoderStream.streamId());
-            fail();
-        } catch (Http3Exception e) {
-            // expected
-            assertThat(e.getCause(), instanceOf(QpackException.class));
-        }
+        Http3Exception e = assertThrows(Http3Exception.class, () -> sendAckForStreamId(decoderStream.streamId()));
+        assertThat(e.getCause(), instanceOf(QpackException.class));
+
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
         finishStreams();
     }
@@ -260,13 +244,9 @@ public class QpackDecoderHandlerTest {
     @Test
     public void invalidIncrement() throws Exception {
         setup(128);
-        try {
-            sendInsertCountIncrement(2);
-            fail();
-        } catch (Http3Exception e) {
-            // expected
-            assertThat(e.getCause(), instanceOf(QpackException.class));
-        }
+        Http3Exception e = assertThrows(Http3Exception.class, () -> sendInsertCountIncrement(2));
+        assertThat(e.getCause(), instanceOf(QpackException.class));
+
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
         finishStreams();
     }

--- a/src/test/java/io/netty/incubator/codec/http3/QpackDecoderTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackDecoderTest.java
@@ -18,9 +18,8 @@ package io.netty.incubator.codec.http3;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collection;
 
@@ -31,16 +30,12 @@ import static java.lang.Math.floorDiv;
 import static java.lang.Math.toIntExact;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assume.assumeThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@RunWith(Parameterized.class)
 public class QpackDecoderTest {
     private static final String FOO = "foo";
     private static final String BAR = "bar";
-    private final int capacity;
-    private final int insertionCount;
     private QpackDecoderDynamicTable table;
     private EmbeddedQuicStreamChannel decoderStream;
 
@@ -49,12 +44,6 @@ public class QpackDecoderTest {
     private int maxEntries;
     private QpackAttributes attributes;
 
-    public QpackDecoderTest(int capacity, int insertionCount) {
-        this.capacity = capacity;
-        this.insertionCount = insertionCount;
-    }
-
-    @Parameterized.Parameters(name = "capacity: {0}, inserts: {1}")
     public static Collection<Object[]> data() {
         int capacity = 128; // maxEntries = 128/32 = 4, maxIndex = 2*4 = 8
         return asList(
@@ -69,36 +58,40 @@ public class QpackDecoderTest {
         );
     }
 
-    @Test
-    public void requiredInsertCountAsInserted() throws Exception {
+    @ParameterizedTest(name = "capacity: {0}, inserts: {1}")
+    @MethodSource("data")
+    public void requiredInsertCountAsInserted(int capacity, int insertionCount) throws Exception {
         setup(capacity);
 
         insertLiterals(insertionCount);
         encodeDecodeVerifyRequiredInsertCount(inserted);
     }
 
-    @Test
-    public void requiredInsertCountLessThanInserted() throws Exception {
+    @ParameterizedTest(name = "capacity: {0}, inserts: {1}")
+    @MethodSource("data")
+    public void requiredInsertCountLessThanInserted(int capacity, int insertionCount) throws Exception {
         setup(capacity);
-        assumeThat(insertionCount, greaterThan(0));
+        assumeTrue(insertionCount > 0);
 
         insertLiterals(insertionCount);
         encodeDecodeVerifyRequiredInsertCount(insertionCount - 1);
     }
 
-    @Test
-    public void requiredInsertCountBehindMax() throws Exception {
+    @ParameterizedTest(name = "capacity: {0}, inserts: {1}")
+    @MethodSource("data")
+    public void requiredInsertCountBehindMax(int capacity, int insertionCount) throws Exception {
         setup(capacity);
-        assumeThat(insertionCount, greaterThan(maxEntries));
+        assumeTrue(insertionCount > maxEntries);
 
         insertLiterals(insertionCount);
         encodeDecodeVerifyRequiredInsertCount(insertionCount - maxEntries + 1);
     }
 
-    @Test
-    public void getWithRelativeIndex() throws Exception {
+    @ParameterizedTest(name = "capacity: {0}, inserts: {1}")
+    @MethodSource("data")
+    public void getWithRelativeIndex(int capacity, int insertionCount) throws Exception {
         setup(capacity);
-        assumeThat(insertionCount, greaterThan(3));
+        assumeTrue(insertionCount > 3);
 
         insertLiterals(insertionCount);
         int requiredInsertCount = encodeDecodeRequiredInsertCount(insertionCount);
@@ -108,10 +101,11 @@ public class QpackDecoderTest {
         verifyField(entry, insertionCount - 2);
     }
 
-    @Test
-    public void getWithPostBaseRelativeIndex() throws Exception {
+    @ParameterizedTest(name = "capacity: {0}, inserts: {1}")
+    @MethodSource("data")
+    public void getWithPostBaseRelativeIndex(int capacity, int insertionCount) throws Exception {
         setup(capacity);
-        assumeThat(insertionCount, greaterThan(2));
+        assumeTrue(insertionCount > 2);
 
         insertLiterals(insertionCount);
         int requiredInsertCount = encodeDecodeRequiredInsertCount(insertionCount - 1);

--- a/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDecoderTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDecoderTest.java
@@ -22,8 +22,8 @@ import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.AsciiString;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
@@ -38,7 +38,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -61,7 +61,7 @@ public class QpackEncoderDecoderTest {
     private final EmbeddedQuicChannel parent = new EmbeddedQuicChannel(true);
     private QpackAttributes attributes;
 
-    @After
+    @AfterEach
     public void tearDown() {
         out.release();
     }
@@ -406,12 +406,7 @@ public class QpackEncoderDecoderTest {
         // Add empty byte to the end of the buffer. This should trigger an exception in the decoder.
         out.writeByte(0);
 
-        try {
-            decode(out, decHeaders);
-            fail();
-        } catch (QpackException exception) {
-            // expected
-        }
+        assertThrows(QpackException.class, () -> decode(out, decHeaders));
     }
 
     private void resetState() {

--- a/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDynamicTableTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDynamicTableTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.incubator.codec.http3;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.incubator.codec.http3.QpackUtil.MAX_HEADER_TABLE_SIZE;
 import static java.lang.Math.toIntExact;
@@ -23,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class QpackEncoderDynamicTableTest {
     private static final QpackHeaderField emptyHeader = new QpackHeaderField("", "");
@@ -47,14 +48,14 @@ public class QpackEncoderDynamicTableTest {
         addAndValidateHeader(table, emptyHeader);
     }
 
-    @Test(expected = QpackException.class)
-    public void negativeCapacityIsDisallowed() throws Exception {
-        newDynamicTable(-1);
+    @Test
+    public void negativeCapacityIsDisallowed() {
+        assertThrows(QpackException.class, () -> newDynamicTable(-1));
     }
 
-    @Test(expected = QpackException.class)
-    public void capacityTooLarge() throws Exception {
-        newDynamicTable(Long.MAX_VALUE);
+    @Test
+    public void capacityTooLarge() {
+        assertThrows(QpackException.class, () -> newDynamicTable(Long.MAX_VALUE));
     }
 
     @Test

--- a/src/test/java/io/netty/incubator/codec/http3/QpackStaticTableTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackStaticTableTest.java
@@ -15,11 +15,11 @@
  */
 package io.netty.incubator.codec.http3;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 
 public class QpackStaticTableTest {
     @Test
@@ -49,7 +49,7 @@ public class QpackStaticTableTest {
         assertEquals(nameIndex1, nameIndex2);
 
         // index should be masked
-        assertTrue((nameIndex1 & QpackStaticTable.MASK_NAME_REF) == QpackStaticTable.MASK_NAME_REF);
+        assertEquals(nameIndex1 & QpackStaticTable.MASK_NAME_REF, QpackStaticTable.MASK_NAME_REF);
         assertEquals(5, nameIndex1 ^ QpackStaticTable.MASK_NAME_REF);
     }
 

--- a/src/test/java/io/netty/incubator/codec/http3/QpackStreamHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackStreamHandlerTest.java
@@ -18,11 +18,11 @@ package io.netty.incubator.codec.http3;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.incubator.codec.quic.QuicStreamType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.incubator.codec.http3.Http3TestUtils.verifyClose;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class QpackStreamHandlerTest {
 


### PR DESCRIPTION
Motivation:

We use junit5 everywhere these days. Let's also use it in http3

Modifications:

Migrate to junit5

Result:

Use latest junit version