### PR TITLE
Upgrade to latest maven release

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
+distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.8.4/apache-maven-3.8.4-bin.zip


### PR DESCRIPTION
Motivation:

We should use the latest maven version when building netty

Modifications:

Update to latest maven release

Result:

Use latest release