### PR TITLE
Upgrade netty and quic codec versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
   <properties>
     <javaModuleName>io.netty.incubator.codec.http3</javaModuleName>
     <skipTests>false</skipTests>
-    <netty.version>4.1.74.Final</netty.version>
+    <netty.version>4.1.77.Final</netty.version>
     <netty.build.version>30</netty.build.version>
-    <netty.quic.version>0.0.26.Final</netty.quic.version>
+    <netty.quic.version>0.0.27.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <junit.version>5.8.2</junit.version>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

There were new releases of netty itself and its quic codec

Modifications:

Upgrade dependencies

Result:

Use latest versions