### PR TITLE
Update netty and netty-incubator-codec-quic versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
   <properties>
     <javaModuleName>io.netty.incubator.codec.http3</javaModuleName>
     <skipTests>false</skipTests>
-    <netty.version>4.1.77.Final</netty.version>
+    <netty.version>4.1.78.Final</netty.version>
     <netty.build.version>30</netty.build.version>
-    <netty.quic.version>0.0.27.Final</netty.quic.version>
+    <netty.quic.version>0.0.28.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <junit.version>5.8.2</junit.version>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

There were new releases

Modifications:

Update versions

Result:

Use latest versions