### PR TITLE
Update to latest netty quic release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <skipTests>false</skipTests>
     <netty.version>4.1.81.Final</netty.version>
     <netty.build.version>30</netty.build.version>
-    <netty.quic.version>0.0.30.Final</netty.quic.version>
+    <netty.quic.version>0.0.33.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <junit.version>5.9.0</junit.version>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

We did release a new version of our quic codec.

Modifications:

Update to 0.0.33.Final

Result:

Use latest version