### PR TITLE
Complete write promise in Http3FrameToHttpObjectCodec

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodec.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodec.java
@@ -41,6 +41,7 @@ import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
+import io.netty.util.concurrent.PromiseCombiner;
 
 import java.net.SocketAddress;
 
@@ -134,7 +135,7 @@ public final class Http3FrameToHttpObjectCodec extends Http3RequestStreamInbound
             if (res.status().equals(HttpResponseStatus.CONTINUE)) {
                 if (res instanceof FullHttpResponse) {
                     final Http3Headers headers = toHttp3Headers(res);
-                    ctx.write(new DefaultHttp3HeadersFrame(headers));
+                    ctx.write(new DefaultHttp3HeadersFrame(headers), promise);
                     ((FullHttpResponse) res).release();
                     return;
                 } else {
@@ -144,9 +145,17 @@ public final class Http3FrameToHttpObjectCodec extends Http3RequestStreamInbound
             }
         }
 
+        // this combiner is created lazily if we need multiple write calls
+        PromiseCombiner combiner = null;
+
         if (msg instanceof HttpMessage) {
             Http3Headers headers = toHttp3Headers((HttpMessage) msg);
-            ctx.write(new DefaultHttp3HeadersFrame(headers));
+            DefaultHttp3HeadersFrame frame = new DefaultHttp3HeadersFrame(headers);
+
+            if (msg instanceof HttpContent && !promise.isVoid()) {
+                combiner = new PromiseCombiner(ctx.executor());
+            }
+            writeWithOptionalCombiner(ctx, frame, promise, combiner);
         }
 
         if (msg instanceof LastHttpContent) {
@@ -154,19 +163,42 @@ public final class Http3FrameToHttpObjectCodec extends Http3RequestStreamInbound
             boolean readable = last.content().isReadable();
             boolean hasTrailers = !last.trailingHeaders().isEmpty();
 
+            if (combiner == null && readable && hasTrailers && !promise.isVoid()) {
+                combiner = new PromiseCombiner(ctx.executor());
+            }
+
             if (readable) {
-                ctx.write(new DefaultHttp3DataFrame(last.content()));
+                writeWithOptionalCombiner(ctx, new DefaultHttp3DataFrame(last.content()), promise, combiner);
             }
             if (hasTrailers) {
                 Http3Headers headers = HttpConversionUtil.toHttp3Headers(last.trailingHeaders(), validateHeaders);
-                ctx.write(new DefaultHttp3HeadersFrame(headers));
+                writeWithOptionalCombiner(ctx, new DefaultHttp3HeadersFrame(headers), promise, combiner);
             }
             if (!readable) {
                 last.release();
             }
             ((QuicStreamChannel) ctx.channel()).shutdownOutput();
+            if (!readable && !hasTrailers && combiner == null) {
+                promise.trySuccess();
+            }
         } else if (msg instanceof HttpContent) {
-            ctx.write(new DefaultHttp3DataFrame(((HttpContent) msg).content()));
+            writeWithOptionalCombiner(ctx, new DefaultHttp3DataFrame(((HttpContent) msg).content()), promise, combiner);
+        }
+
+        if (combiner != null) {
+            combiner.finish(promise);
+        }
+    }
+
+    /**
+     * Write a message. If there is a combiner, add a new write promise to that combiner. If there is no combiner
+     * ({@code null}), use the {@code outerPromise} directly as the write promise.
+     */
+    private static void writeWithOptionalCombiner(ChannelHandlerContext ctx, Object msg, ChannelPromise outerPromise, PromiseCombiner combiner) {
+        if (combiner == null) {
+            ctx.write(msg, outerPromise);
+        } else {
+            combiner.add(ctx.write(msg));
         }
     }
 

--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodec.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodec.java
@@ -194,7 +194,12 @@ public final class Http3FrameToHttpObjectCodec extends Http3RequestStreamInbound
      * Write a message. If there is a combiner, add a new write promise to that combiner. If there is no combiner
      * ({@code null}), use the {@code outerPromise} directly as the write promise.
      */
-    private static void writeWithOptionalCombiner(ChannelHandlerContext ctx, Object msg, ChannelPromise outerPromise, PromiseCombiner combiner) {
+    private static void writeWithOptionalCombiner(
+            ChannelHandlerContext ctx,
+            Object msg,
+            ChannelPromise outerPromise,
+            PromiseCombiner combiner
+    ) {
         if (combiner == null) {
             ctx.write(msg, outerPromise);
         } else {

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
@@ -18,6 +18,7 @@ package io.netty.incubator.codec.http3;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
 import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
@@ -39,6 +40,8 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -550,6 +553,95 @@ public class Http3FrameToHttpObjectCodecTest {
         assertThat(headerFrame.headers().get("key").toString(), is("value"));
 
         assertTrue(ch.isOutputShutdown());
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testEncodeFullPromiseCompletes() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        ChannelFuture writeFuture = ch.writeOneOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world"));
+        ch.flushOutbound();
+        assertTrue(writeFuture.isSuccess());
+
+        Http3HeadersFrame headersFrame = ch.readOutbound();
+        Http3Headers headers = headersFrame.headers();
+
+        assertThat(headers.scheme().toString(), is("https"));
+        assertThat(headers.method().toString(), is("GET"));
+        assertThat(headers.path().toString(), is("/hello/world"));
+        assertTrue(ch.isOutputShutdown());
+
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testEncodeEmptyLastPromiseCompletes() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        ChannelFuture f1 = ch.writeOneOutbound(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world"));
+        ChannelFuture f2 = ch.writeOneOutbound(new DefaultLastHttpContent());
+        ch.flushOutbound();
+        assertTrue(f1.isSuccess());
+        assertTrue(f2.isSuccess());
+
+        Http3HeadersFrame headersFrame = ch.readOutbound();
+        Http3Headers headers = headersFrame.headers();
+
+        assertThat(headers.scheme().toString(), is("https"));
+        assertThat(headers.method().toString(), is("GET"));
+        assertThat(headers.path().toString(), is("/hello/world"));
+        assertTrue(ch.isOutputShutdown());
+
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testEncodeMultiplePromiseCompletes() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        ChannelFuture f1 = ch.writeOneOutbound(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world"));
+        ChannelFuture f2 = ch.writeOneOutbound(new DefaultLastHttpContent(Unpooled.wrappedBuffer("foo".getBytes(StandardCharsets.UTF_8))));
+        ch.flushOutbound();
+        assertTrue(f1.isSuccess());
+        assertTrue(f2.isSuccess());
+
+        Http3HeadersFrame headersFrame = ch.readOutbound();
+        Http3Headers headers = headersFrame.headers();
+
+        assertThat(headers.scheme().toString(), is("https"));
+        assertThat(headers.method().toString(), is("GET"));
+        assertThat(headers.path().toString(), is("/hello/world"));
+        assertTrue(ch.isOutputShutdown());
+
+        Http3DataFrame dataFrame = ch.readOutbound();
+        assertEquals("foo", dataFrame.content().toString(StandardCharsets.UTF_8));
+
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testEncodeTrailersCompletes() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        ChannelFuture f1 = ch.writeOneOutbound(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world"));
+        LastHttpContent last = new DefaultLastHttpContent(Unpooled.wrappedBuffer("foo".getBytes(StandardCharsets.UTF_8)));
+        last.trailingHeaders().add("foo", "bar");
+        ChannelFuture f2 = ch.writeOneOutbound(last);
+        ch.flushOutbound();
+        assertTrue(f1.isSuccess());
+        assertTrue(f2.isSuccess());
+
+        Http3HeadersFrame headersFrame = ch.readOutbound();
+        Http3Headers headers = headersFrame.headers();
+
+        assertThat(headers.scheme().toString(), is("https"));
+        assertThat(headers.method().toString(), is("GET"));
+        assertThat(headers.path().toString(), is("/hello/world"));
+        assertTrue(ch.isOutputShutdown());
+
+        Http3DataFrame dataFrame = ch.readOutbound();
+        assertEquals("foo", dataFrame.content().toString(StandardCharsets.UTF_8));
+
+        Http3HeadersFrame trailingHeadersFrame = ch.readOutbound();
+        assertEquals("bar", trailingHeadersFrame.headers().get("foo").toString());
+
         assertFalse(ch.finish());
     }
 

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
@@ -559,7 +559,8 @@ public class Http3FrameToHttpObjectCodecTest {
     @Test
     public void testEncodeFullPromiseCompletes() {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
-        ChannelFuture writeFuture = ch.writeOneOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world"));
+        ChannelFuture writeFuture = ch.writeOneOutbound(new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world"));
         ch.flushOutbound();
         assertTrue(writeFuture.isSuccess());
 
@@ -577,7 +578,8 @@ public class Http3FrameToHttpObjectCodecTest {
     @Test
     public void testEncodeEmptyLastPromiseCompletes() {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
-        ChannelFuture f1 = ch.writeOneOutbound(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world"));
+        ChannelFuture f1 = ch.writeOneOutbound(new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world"));
         ChannelFuture f2 = ch.writeOneOutbound(new DefaultLastHttpContent());
         ch.flushOutbound();
         assertTrue(f1.isSuccess());
@@ -597,8 +599,10 @@ public class Http3FrameToHttpObjectCodecTest {
     @Test
     public void testEncodeMultiplePromiseCompletes() {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
-        ChannelFuture f1 = ch.writeOneOutbound(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world"));
-        ChannelFuture f2 = ch.writeOneOutbound(new DefaultLastHttpContent(Unpooled.wrappedBuffer("foo".getBytes(StandardCharsets.UTF_8))));
+        ChannelFuture f1 = ch.writeOneOutbound(new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world"));
+        ChannelFuture f2 = ch.writeOneOutbound(new DefaultLastHttpContent(
+                Unpooled.wrappedBuffer("foo".getBytes(StandardCharsets.UTF_8))));
         ch.flushOutbound();
         assertTrue(f1.isSuccess());
         assertTrue(f2.isSuccess());
@@ -620,8 +624,10 @@ public class Http3FrameToHttpObjectCodecTest {
     @Test
     public void testEncodeTrailersCompletes() {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
-        ChannelFuture f1 = ch.writeOneOutbound(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world"));
-        LastHttpContent last = new DefaultLastHttpContent(Unpooled.wrappedBuffer("foo".getBytes(StandardCharsets.UTF_8)));
+        ChannelFuture f1 = ch.writeOneOutbound(new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world"));
+        LastHttpContent last = new DefaultLastHttpContent(
+                Unpooled.wrappedBuffer("foo".getBytes(StandardCharsets.UTF_8)));
         last.trailingHeaders().add("foo", "bar");
         ChannelFuture f2 = ch.writeOneOutbound(last);
         ch.flushOutbound();


### PR DESCRIPTION
Motivation:

Before this patch, `Http3FrameToHttpObjectCodec` ignored the write promise. It would never complete.

Modifications:

Change `Http3FrameToHttpObjectCodec` so that the write promise is forwarded to outbound handlers. If multiple messages need to be written for one promise, use `PromiseCombiner` to complete the write promise when all outbound writes are done.

Result:

Writes that go through `Http3FrameToHttpObjectCodec` have their promises completed properly.