### PR TITLE
Fix Host->:authority translation when URI is in origin-form

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/HttpConversionUtil.java
+++ b/src/main/java/io/netty/incubator/codec/http3/HttpConversionUtil.java
@@ -372,10 +372,14 @@ public final class HttpConversionUtil {
             out.method(request.method().asciiName());
             setHttp3Scheme(inHeaders, requestTargetUri, out);
 
-            if (!isOriginForm(requestTargetUri) && !isAsteriskForm(requestTargetUri)) {
-                // Attempt to take from HOST header before taking from the request-line
-                String host = inHeaders.getAsString(HttpHeaderNames.HOST);
-                setHttp3Authority((host == null || host.isEmpty()) ? requestTargetUri.getAuthority() : host, out);
+            // Attempt to take from HOST header before taking from the request-line
+            String host = inHeaders.getAsString(HttpHeaderNames.HOST);
+            if (host != null && !host.isEmpty()) {
+                setHttp3Authority(host, out);
+            } else {
+                if (!isOriginForm(request.uri()) && !isAsteriskForm(request.uri())) {
+                    setHttp3Authority(requestTargetUri.getAuthority(), out);
+                }
             }
         } else if (in instanceof HttpResponse) {
             HttpResponse response = (HttpResponse) in;


### PR DESCRIPTION
Motivation:

Before this patch, HTTP/1->HTTP/3 conversion would only add the :authority pseudo header if the URI was in absolute- or authority-form. However, when there is a Host header, there is no reason why it couldn't be translated in asterisk-form or origin-form as well.

Modification:

If a Host header is present, translate it to the :authority pseudo-header, for all request URI types.

Result:

Translation produces the :authority header for asterisk-form and origin-form request URIs, when the Host header is present.