### PR TITLE
Fix test failure from netty-codec-http upgrade

### DIFF
--- a/src/test/java/io/netty/incubator/codec/http3/HttpConversionUtilTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/HttpConversionUtilTest.java
@@ -139,7 +139,7 @@ public class HttpConversionUtilTest {
 
     @Test
     public void stripTEHeadersAccountsForOWS() {
-        HttpHeaders inHeaders = new DefaultHttpHeaders();
+        HttpHeaders inHeaders = new DefaultHttpHeaders(false);
         inHeaders.add(TE, " " + TRAILERS + " ");
         Http3Headers out = new DefaultHttp3Headers();
         HttpConversionUtil.toHttp3Headers(inHeaders, out);


### PR DESCRIPTION
Motivation:

A change in netty-codec-http causes this test to fail with "a header value contains prohibited character 0x20 at index 0". The offending commit is probably https://github.com/netty/netty/commit/980f48a9089849adda1d5035eb3ac5ba567a3b23 .

Modification:

Disable validation of the `inHeaders` instance, since it is not the class under test.

Result:

The test passes.