### PR TITLE
Upgrade netty and quic-codec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
   <properties>
     <javaModuleName>io.netty.incubator.codec.http3</javaModuleName>
     <skipTests>false</skipTests>
-    <netty.version>4.1.85.Final</netty.version>
+    <netty.version>4.1.89.Final</netty.version>
     <netty.build.version>30</netty.build.version>
-    <netty.quic.version>0.0.34.Final</netty.quic.version>
+    <netty.quic.version>0.0.36.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <junit.version>5.9.0</junit.version>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

There were new releases of netty itself but also the quic codec

Modifications:

Update to latest release

Result:

Use latest releases