### PR TITLE
Don't set a default MAX_HEADER_LIST_SIZE

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
@@ -32,7 +32,6 @@ import static io.netty.incubator.codec.http3.Http3ErrorCode.H3_INTERNAL_ERROR;
 import static io.netty.incubator.codec.quic.QuicStreamType.UNIDIRECTIONAL;
 
 final class Http3CodecUtils {
-    static final long DEFAULT_MAX_HEADER_LIST_SIZE = 0xffffffffL;
 
     // See https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.8
     static final long MIN_RESERVED_FRAME_TYPE = 0x1f * 1 + 0x21;

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ConnectionHandler.java
@@ -65,8 +65,8 @@ public abstract class Http3ConnectionHandler extends ChannelInboundHandlerAdapte
         }
         Long maxFieldSectionSize = localSettings.get(Http3SettingsFrame.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE);
         if (maxFieldSectionSize == null) {
-            maxFieldSectionSize = Http3CodecUtils.DEFAULT_MAX_HEADER_LIST_SIZE;
-            localSettings.put(Http3SettingsFrame.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE, maxFieldSectionSize);
+            // Just use the maximum value we can represent via a Long.
+            maxFieldSectionSize = Long.MAX_VALUE;
         }
         qpackDecoder = new QpackDecoder(localSettings);
         qpackEncoder = new QpackEncoder();


### PR DESCRIPTION
Motivation:

MAX_HEADER_LIST_SIZE is unlimited by default per RFC.

Modifications:

Ensure we don't set a value when the user does not supply one.

Result:

More correct implementation. Fixes https://github.com/netty/netty-incubator-codec-http3/issues/209