### PR TITLE
Disable dynamic qpack table by default

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3ClientConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ClientConnectionHandler.java
@@ -31,7 +31,7 @@ public final class Http3ClientConnectionHandler extends Http3ConnectionHandler {
      * Create a new instance.
      */
     public Http3ClientConnectionHandler() {
-        this(null, null, null, null, false);
+        this(null, null, null, null, true);
     }
 
     /**

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
@@ -39,7 +39,7 @@ public final class Http3ServerConnectionHandler extends Http3ConnectionHandler {
      *                              This handler will receive {@link Http3HeadersFrame} and {@link Http3DataFrame}s.
      */
     public Http3ServerConnectionHandler(ChannelHandler requestStreamHandler) {
-        this(requestStreamHandler, null, null, null, false);
+        this(requestStreamHandler, null, null, null, true);
     }
 
     /**
@@ -54,7 +54,7 @@ public final class Http3ServerConnectionHandler extends Http3ConnectionHandler {
      *                                              {@link ChannelHandler} for unknown inbound stream types or
      *                                              {@code null} if no special handling should be done.
      * @param localSettings                         the local {@link Http3SettingsFrame} that should be sent to the
-     *                                             remote peer or {@code null} if the default settings should be used.
+     *                                              remote peer or {@code null} if the default settings should be used.
      * @param disableQpackDynamicTable              If QPACK dynamic table should be disabled.
      */
     public Http3ServerConnectionHandler(ChannelHandler requestStreamHandler,


### PR DESCRIPTION
Motivation:

Let's disable the dynamic table for now as there seems to be a bug which can cause decoding errors

Modifications:

Disable the dynamic table by default

Result:

Workaround for https://github.com/netty/netty-incubator-codec-http3/issues/152