### PR TITLE
Upgrade to netty 4.1.94.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
   <properties>
     <javaModuleName>io.netty.incubator.codec.http3</javaModuleName>
     <skipTests>false</skipTests>
-    <netty.version>4.1.93.Final</netty.version>
+    <netty.version>4.1.94.Final</netty.version>
     <netty.build.version>31</netty.build.version>
     <netty.quic.version>0.0.46.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>


### PR DESCRIPTION
Motivation:

A new version of netty is out

Modifications:

Upgrade to 4.1.94.Final

Result:

Use latest netty version