### PR TITLE
Transform multiple HTTP/3 frames in one FIN frame properly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -456,5 +456,11 @@
       <version>3.6.28</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <version>1.75</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/io/netty/incubator/codec/http3/Http3RequestStreamInboundHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3RequestStreamInboundHandler.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.incubator.codec.quic.QuicException;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -63,8 +64,10 @@ public abstract class Http3RequestStreamInboundHandler extends ChannelInboundHan
 
     @Override
     public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
-        // in case the handler is removed between channelRead and channelReadComplete. Should be rare
-        handleBufferedMessage(ctx, ((QuicStreamChannel) ctx.channel()).isInputShutdown());
+        if (bufferedMessage != null) {
+            ReferenceCountUtil.release(bufferedMessage);
+            bufferedMessage = null;
+        }
     }
 
     private void handleBufferedMessage(ChannelHandlerContext ctx, boolean noMoreInput) throws Exception {

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
@@ -1018,7 +1018,9 @@ data.release();
                                         DefaultHttp3HeadersFrame responseHeaders = new DefaultHttp3HeadersFrame();
                                         responseHeaders.headers().status(HttpResponseStatus.OK.codeAsText());
                                         ctx.write(responseHeaders, ctx.voidPromise());
-                                        ctx.write(new DefaultHttp3DataFrame(ByteBufUtil.encodeString(ctx.alloc(), CharBuffer.wrap("foo"), CharsetUtil.UTF_8)), ctx.voidPromise());
+                                        ctx.write(new DefaultHttp3DataFrame(ByteBufUtil.encodeString(
+                                                ctx.alloc(), CharBuffer.wrap("foo"), CharsetUtil.UTF_8)),
+                                                ctx.voidPromise());
                                         // send a fin, this also flushes
                                         ((DuplexChannel) ctx.channel()).shutdownOutput();
                                     } else {
@@ -1051,7 +1053,6 @@ data.release();
                     .remoteAddress(server.localAddress())
                     .localAddress(client.localAddress())
                     .connect().get();
-
 
             BlockingQueue<Object> received = new LinkedBlockingQueue<>();
             QuicStreamChannel stream = Http3.newRequestStream(quicChannel, new Http3RequestStreamInitializer() {

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
@@ -16,12 +16,21 @@
 
 package io.netty.incubator.codec.http3;
 
+import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DuplexChannel;
+import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
@@ -44,16 +53,30 @@ import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.incubator.codec.quic.InsecureQuicTokenHandler;
+import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.incubator.codec.quic.QuicSslContextBuilder;
+import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
+import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -958,5 +981,104 @@ data.release();
         assertTrue(ch.isOutputShutdown());
 
         assertFalse(ch.finish());
+    }
+
+    @Test
+    public void multipleFramesInFin() throws InterruptedException, CertificateException, ExecutionException {
+        EventLoopGroup group = new NioEventLoopGroup(1);
+        try {
+            Bootstrap bootstrap = new Bootstrap()
+                    .channel(NioDatagramChannel.class)
+                    .handler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel ch) throws Exception {
+                            // initialized below
+                        }
+                    })
+                    .group(group);
+
+            SelfSignedCertificate cert = new SelfSignedCertificate();
+
+            Channel server = bootstrap.bind("127.0.0.1", 0).sync().channel();
+            server.pipeline().addLast(Http3.newQuicServerCodecBuilder()
+                    .initialMaxData(10000000)
+                    .initialMaxStreamDataBidirectionalLocal(1000000)
+                    .initialMaxStreamDataBidirectionalRemote(1000000)
+                    .initialMaxStreamsBidirectional(100)
+                    .sslContext(QuicSslContextBuilder.forServer(cert.key(), null, cert.cert())
+                            .applicationProtocols(Http3.supportedApplicationProtocols()).build())
+                    .tokenHandler(InsecureQuicTokenHandler.INSTANCE)
+                    .handler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel ch) throws Exception {
+                            ch.pipeline().addLast(new Http3ServerConnectionHandler(new ChannelInboundHandlerAdapter() {
+                                @Override
+                                public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                                    if (msg instanceof Http3HeadersFrame) {
+                                        DefaultHttp3HeadersFrame responseHeaders = new DefaultHttp3HeadersFrame();
+                                        responseHeaders.headers().status(HttpResponseStatus.OK.codeAsText());
+                                        ctx.write(responseHeaders, ctx.voidPromise());
+                                        ctx.write(new DefaultHttp3DataFrame(ByteBufUtil.encodeString(ctx.alloc(), CharBuffer.wrap("foo"), CharsetUtil.UTF_8)), ctx.voidPromise());
+                                        // send a fin, this also flushes
+                                        ((DuplexChannel) ctx.channel()).shutdownOutput();
+                                    } else {
+                                        super.channelRead(ctx, msg);
+                                    }
+                                }
+                            }));
+                        }
+                    })
+                    .build());
+
+            Channel client = bootstrap.bind("127.0.0.1", 0).sync().channel();
+            client.config().setAutoRead(true);
+            client.pipeline().addLast(Http3.newQuicClientCodecBuilder()
+                    .initialMaxData(10000000)
+                    .initialMaxStreamDataBidirectionalLocal(1000000)
+                    .sslContext(QuicSslContextBuilder.forClient()
+                            .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                            .applicationProtocols(Http3.supportedApplicationProtocols())
+                            .build())
+                    .build());
+
+            QuicChannel quicChannel = QuicChannel.newBootstrap(client)
+                    .handler(new ChannelInitializer<QuicChannel>() {
+                        @Override
+                        protected void initChannel(QuicChannel ch) throws Exception {
+                            ch.pipeline().addLast(new Http3ClientConnectionHandler());
+                        }
+                    })
+                    .remoteAddress(server.localAddress())
+                    .localAddress(client.localAddress())
+                    .connect().get();
+
+
+            BlockingQueue<Object> received = new LinkedBlockingQueue<>();
+            QuicStreamChannel stream = Http3.newRequestStream(quicChannel, new Http3RequestStreamInitializer() {
+                @Override
+                protected void initRequestStream(QuicStreamChannel ch) {
+                    ch.pipeline()
+                            .addLast(new Http3FrameToHttpObjectCodec(false))
+                            .addLast(new ChannelInboundHandlerAdapter() {
+                                @Override
+                                public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                                    received.put(msg);
+                                }
+                            });
+                }
+            }).get();
+            DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+            request.headers().add(HttpHeaderNames.HOST, "localhost");
+            stream.writeAndFlush(request);
+
+            HttpResponse respHeaders = (HttpResponse) received.poll(20, TimeUnit.SECONDS);
+            assertThat(respHeaders.status(), is(HttpResponseStatus.OK));
+            assertThat(respHeaders, not(instanceOf(LastHttpContent.class))); // this assertion failed before this PR
+            LastHttpContent respBody = (LastHttpContent) received.poll(20, TimeUnit.SECONDS);
+            assertThat(respBody.content().toString(CharsetUtil.UTF_8), is("foo"));
+            respBody.release();
+        } finally {
+            group.shutdownGracefully();
+        }
     }
 }


### PR DESCRIPTION
Motivation:

When a single QUIC frame has the FIN flag set, but contains multiple HTTP/3 frames, all those frames would be recognized by Http3RequestStreamInboundHandler as the last frame. With Http3FrameToHttpObjectCodec, this leads to multiple LastHttpContent.

Modification:

In Http3RequestStreamInboundHandler, delay every message by one read call. In the read call, the previous message is forwarded without isLast. In readComplete, the last message is forwarded with isLast from the old heuristic.

I'm not a big fan of this buffering approach, but don't really see a better way. Alternatives welcome.

For the test, I decided to go with a full integration test to properly reproduce the failure condition.

Result:

isLast is only set for the truly last message. Only the truly last message implements LastHttpContent.