### PR TITLE
Update workflows to make things more robust when it comes to caching

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -36,6 +36,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: build-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
@@ -43,7 +44,7 @@ jobs:
             build-cache-m2-repository-
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
         with:
           key: docker-cache-build-{hash}

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -45,6 +45,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: deploy-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
@@ -52,7 +53,7 @@ jobs:
             deploy-cache-m2-repository-
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
         with:
           key: docker-cache-deploy-{hash}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -37,6 +37,7 @@ jobs:
           distribution: 'zulu'
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: verify-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
@@ -53,6 +54,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: pr-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
@@ -60,7 +62,7 @@ jobs:
             pr-cache-m2-repository-
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
         with:
           key: docker-cache-pr-build-{hash}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -65,6 +65,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: release-cache-m2-repository-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,6 +46,7 @@ jobs:
 
     # Cache .m2/repository
     - uses: actions/cache@v3
+      continue-on-error: true
       with:
         path: ~/.m2/repository
         key: ${{ matrix.language }}-cache-m2-repository-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
Motivation:

When caching fails during workflow execution we should still continue the build as its just an optimization. Also we should use the new fork for docker layer caching

Modifications:

- Update action that does the docker layer caching to the new fork
- Ignore errors during caching

Result:

More stable builds