### PR TITLE
Change API of Http3RequestStreamInboundHandler to better handle FIN

### DIFF
--- a/src/test/java/io/netty/incubator/codec/http3/Http3ServerPushStreamManagerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3ServerPushStreamManagerTest.java
@@ -55,13 +55,18 @@ public class Http3ServerPushStreamManagerTest {
     public void setUp() throws Exception {
         connectionHandler = new Http3ServerConnectionHandler(new Http3RequestStreamInboundHandler() {
             @Override
-            protected void channelRead(ChannelHandlerContext ctx, Http3HeadersFrame frame, boolean isLast) {
+            protected void channelRead(ChannelHandlerContext ctx, Http3HeadersFrame frame) {
                 ReferenceCountUtil.release(frame);
             }
 
             @Override
-            protected void channelRead(ChannelHandlerContext ctx, Http3DataFrame frame, boolean isLast) {
+            protected void channelRead(ChannelHandlerContext ctx, Http3DataFrame frame) {
                 ReferenceCountUtil.release(frame);
+            }
+
+            @Override
+            protected void channelInputClosed(ChannelHandlerContext ctx) {
+                // NOOP
             }
         }, null, null, null, true);
         channel = new EmbeddedQuicChannel(true, connectionHandler);

--- a/src/test/java/io/netty/incubator/codec/http3/Http3SpecTestServer.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3SpecTestServer.java
@@ -73,31 +73,27 @@ public final class Http3SpecTestServer {
                                         ch.pipeline().addLast(new Http3RequestStreamInboundHandler() {
 
                                             @Override
-                                            protected void channelRead(ChannelHandlerContext ctx,
-                                                                       Http3HeadersFrame frame, boolean isLast) {
-                                                if (isLast) {
-                                                    writeResponse(ctx);
-                                                }
+                                            protected void channelRead(
+                                                    ChannelHandlerContext ctx, Http3HeadersFrame frame) {
+
                                                 ReferenceCountUtil.release(frame);
                                             }
 
                                             @Override
-                                            protected void channelRead(ChannelHandlerContext ctx,
-                                                                       Http3DataFrame frame, boolean isLast) {
-                                                if (isLast) {
-                                                    writeResponse(ctx);
-                                                }
+                                            protected void channelRead(
+                                                    ChannelHandlerContext ctx, Http3DataFrame frame) {
                                                 ReferenceCountUtil.release(frame);
                                             }
 
-                                            private void writeResponse(ChannelHandlerContext ctx) {
+                                            @Override
+                                            protected void channelInputClosed(ChannelHandlerContext ctx) {
                                                 Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
                                                 headersFrame.headers().status("404");
                                                 headersFrame.headers().add("server", "netty");
                                                 headersFrame.headers().addInt("content-length", CONTENT.length);
                                                 ctx.write(headersFrame);
                                                 ctx.writeAndFlush(new DefaultHttp3DataFrame(
-                                                        Unpooled.wrappedBuffer(CONTENT)))
+                                                                Unpooled.wrappedBuffer(CONTENT)))
                                                         .addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
                                             }
                                         });

--- a/src/test/java/io/netty/incubator/codec/http3/example/Http3ServerExample.java
+++ b/src/test/java/io/netty/incubator/codec/http3/example/Http3ServerExample.java
@@ -80,31 +80,26 @@ public final class Http3ServerExample {
                                         ch.pipeline().addLast(new Http3RequestStreamInboundHandler() {
 
                                             @Override
-                                            protected void channelRead(ChannelHandlerContext ctx,
-                                                                       Http3HeadersFrame frame, boolean isLast) {
-                                                if (isLast) {
-                                                    writeResponse(ctx);
-                                                }
+                                            protected void channelRead(
+                                                    ChannelHandlerContext ctx, Http3HeadersFrame frame) {
                                                 ReferenceCountUtil.release(frame);
                                             }
 
                                             @Override
-                                            protected void channelRead(ChannelHandlerContext ctx,
-                                                                       Http3DataFrame frame, boolean isLast) {
-                                                if (isLast) {
-                                                    writeResponse(ctx);
-                                                }
+                                            protected void channelRead(
+                                                    ChannelHandlerContext ctx, Http3DataFrame frame) {
                                                 ReferenceCountUtil.release(frame);
                                             }
 
-                                            private void writeResponse(ChannelHandlerContext ctx) {
+                                            @Override
+                                            protected void channelInputClosed(ChannelHandlerContext ctx) {
                                                 Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
                                                 headersFrame.headers().status("404");
                                                 headersFrame.headers().add("server", "netty");
                                                 headersFrame.headers().addInt("content-length", CONTENT.length);
                                                 ctx.write(headersFrame);
                                                 ctx.writeAndFlush(new DefaultHttp3DataFrame(
-                                                        Unpooled.wrappedBuffer(CONTENT)))
+                                                                Unpooled.wrappedBuffer(CONTENT)))
                                                         .addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
                                             }
                                         });


### PR DESCRIPTION
Motivation:

5740c520bbabd490a448c97a4b8f0574115b68f6 introduced a workaround for correctly handle FIN when multiple http3 frames are contained in one QUIC frame. While this worked it was kind of hacky and we should better adjust the API.

Modifications:

- Change Http3RequestStreamInboundHandler API for handling frames and FIN
- Adjust tests.

Result:

Better fix for handling multiple frames