### PR TITLE
Remove dependency on os-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,13 +81,6 @@
   </properties>
 
   <build>
-    <extensions>
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
-      </extension>
-    </extensions>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Motivation:

os-maven-plugin is not required anymore.

Modifications:

Remove os-maven-plugin

Result:

Cleanup