### PR TITLE
QPACK: Correctly encode / decode indexes

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/QpackDecoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackDecoder.java
@@ -307,7 +307,7 @@ final class QpackDecoder {
         } else {
             final int idx = decodePrefixedIntegerAsInt(in, 6);
             assert idx >= 0;
-            field = dynamicTable.getEntryRelativeEncodedField(base - idx);
+            field = dynamicTable.getEntryRelativeEncodedField(base - idx - 1);
         }
         sink.accept(field.name, field.value);
     }
@@ -349,7 +349,7 @@ final class QpackDecoder {
         } else {
             final int idx = decodePrefixedIntegerAsInt(in, 4);
             assert idx >= 0;
-            name = dynamicTable.getEntryRelativeEncodedField(base - idx).name;
+            name = dynamicTable.getEntryRelativeEncodedField(base - idx - 1).name;
         }
         final CharSequence value = decodeHuffmanEncodedLiteral(in, 7);
         sink.accept(name, value);

--- a/src/main/java/io/netty/incubator/codec/http3/QpackEncoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackEncoder.java
@@ -393,7 +393,7 @@ final class QpackEncoder {
         // +---+---+---+---+---+---+---+---+
         // | 1 | T |      Index (6+)       |
         // +---+---+-----------------------+
-        encodePrefixedInteger(out, (byte) 0b1000_0000, 6, base - index);
+        encodePrefixedInteger(out, (byte) 0b1000_0000, 6, base - index - 1);
     }
 
     private void encodePostBaseIndexed(ByteBuf out, int base, int index) {
@@ -431,7 +431,7 @@ final class QpackEncoder {
         //   |  Value String (Length bytes)  |
         //   +-------------------------------+
         // TODO: Force N = 0 till we support sensitivity detector
-        encodePrefixedInteger(out, (byte) 0b0101_0000, 4, base - nameIndex);
+        encodePrefixedInteger(out, (byte) 0b0101_0000, 4, base - nameIndex - 1);
         encodeStringLiteral(out, value);
     }
 


### PR DESCRIPTION
Motivation:

We did had an error in how to encoded / decoded indexes when using the dynamic table.

Modifications:

Correct decoding / encoding

Result:

Dynamic table works as expected. Fixes https://github.com/netty/netty-incubator-codec-http3/issues/249