### PR TITLE
Fix absolute indexing in the dynamic table

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/QpackEncoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackEncoder.java
@@ -91,7 +91,7 @@ final class QpackEncoder {
             // +---+---------------------------+
             // | S |      Delta Base (7+)      |
             // +---+---------------------------+
-            encodePrefixedInteger(out, (byte) 0b0, 8, requiredInsertCount);
+            encodePrefixedInteger(out, (byte) 0b0, 8, dynamicTable.encodedRequiredInsertCount(requiredInsertCount));
             if (base >= requiredInsertCount) {
                 encodePrefixedInteger(out, (byte) 0b0, 7, base - requiredInsertCount);
             } else {
@@ -140,7 +140,7 @@ final class QpackEncoder {
         if (tracker.isEmpty()) {
             streamTrackers.remove(streamId);
         }
-        if (nextCount > 0) {
+        if (nextCount >= 0) {
             dynamicTable.acknowledgeInsertCount(nextCount);
         }
     }
@@ -156,7 +156,7 @@ final class QpackEncoder {
         final StreamTracker tracker = streamTrackers.remove(streamId);
         if (tracker != null) {
             int nextCount;
-            while ((nextCount = tracker.takeNextInsertCount()) > 0) {
+            while ((nextCount = tracker.takeNextInsertCount()) >= 0) {
                 dynamicTable.acknowledgeInsertCount(nextCount);
             }
         }

--- a/src/test/java/io/netty/incubator/codec/http3/QpackDecoderHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackDecoderHandlerTest.java
@@ -332,12 +332,13 @@ public class QpackDecoderHandlerTest {
     }
 
     private void verifyRequiredInsertCount(int insertCount) {
-        assertThat("Unexpected dynamic table insert count.", dynamicTable.requiredInsertCount(),
+        assertThat("Unexpected dynamic table insert count.",
+                dynamicTable.encodedRequiredInsertCount(dynamicTable.insertCount()),
                 is(insertCount == 0 ? 0 : insertCount % maxEntries + 1));
     }
 
     private void verifyKnownReceivedCount(int receivedCount) {
-        assertThat("Unexpected dynamic table known received count.", dynamicTable.knownReceivedCount(),
+        assertThat("Unexpected dynamic table known received count.", dynamicTable.encodedKnownReceivedCount(),
                 is(receivedCount == 0 ? 0 : receivedCount % maxEntries + 1));
     }
 }

--- a/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDecoderTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDecoderTest.java
@@ -499,12 +499,13 @@ public class QpackEncoderDecoderTest {
     }
 
     private void verifyRequiredInsertCount(int insertCount) {
-        assertThat("Unexpected dynamic table insert count.", encDynamicTable.requiredInsertCount(),
+        assertThat("Unexpected dynamic table insert count.",
+                encDynamicTable.encodedRequiredInsertCount(encDynamicTable.insertCount()),
                 is(insertCount == 0 ? 0 : insertCount % (2 * maxEntries) + 1));
     }
 
     private void verifyKnownReceivedCount(int receivedCount) {
-        assertThat("Unexpected dynamic table known received count.", encDynamicTable.knownReceivedCount(),
+        assertThat("Unexpected dynamic table known received count.", encDynamicTable.encodedKnownReceivedCount(),
                 is(receivedCount == 0 ? 0 : receivedCount % (2 * maxEntries) + 1));
     }
 

--- a/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDynamicTableTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDynamicTableTest.java
@@ -160,7 +160,7 @@ public class QpackEncoderDynamicTableTest {
         table.addReferenceToEntry(fooBarHeader.name, fooBarHeader.value, idx);
         table.acknowledgeInsertCount(idx);
 
-        assertThat("Unexpected known received count.", table.knownReceivedCount(), is(2));
+        assertThat("Unexpected known received count.", table.encodedKnownReceivedCount(), is(2));
     }
 
     @Test
@@ -174,10 +174,10 @@ public class QpackEncoderDynamicTableTest {
         table.addReferenceToEntry(fooBarHeader.name, fooBarHeader.value, idx2);
 
         table.acknowledgeInsertCount(idx2);
-        assertThat("Unexpected known received count.", table.knownReceivedCount(), is(3));
+        assertThat("Unexpected known received count.", table.encodedKnownReceivedCount(), is(3));
 
         table.acknowledgeInsertCount(idx1);
-        assertThat("Unexpected known received count.", table.knownReceivedCount(), is(3)); // already acked
+        assertThat("Unexpected known received count.", table.encodedKnownReceivedCount(), is(3)); // already acked
     }
 
     @Test
@@ -248,7 +248,8 @@ public class QpackEncoderDynamicTableTest {
     }
 
     private void verifyInsertCount(QpackEncoderDynamicTable table) {
-        assertThat("Unexpected required insert count.", table.requiredInsertCount(), is(expectedInsertCount()));
+        assertThat("Unexpected required insert count.",
+                table.encodedRequiredInsertCount(table.insertCount()), is(expectedInsertCount()));
     }
 
     private int expectedInsertCount() {


### PR DESCRIPTION
Motivation:

As per rfc9204 the absolute indexing needs to start with index 0. Our implementation did start with index 1 which broke clients like chrome.

Modifications:

- Start with index 0
- Correctly calculate base when encoding
- Adjust method names to better reflect what the methods actually do
- Add javadocs

Result:

Fixes https://github.com/netty/netty-incubator-codec-http3/issues/152