### PR TITLE
QPACK: Max table capacity value should be used to encode required ins…

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3ConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ConnectionHandler.java
@@ -26,6 +26,9 @@ import io.netty.incubator.codec.quic.QuicStreamType;
 import java.util.function.LongFunction;
 
 import static io.netty.incubator.codec.http3.Http3RequestStreamCodecState.NO_STATE;
+import static io.netty.incubator.codec.http3.Http3SettingsFrame.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS;
+import static io.netty.incubator.codec.http3.Http3SettingsFrame.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY;
+import static java.lang.Math.toIntExact;
 
 /**
  * Handler that handles <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32">HTTP3</a> connections.
@@ -68,7 +71,9 @@ public abstract class Http3ConnectionHandler extends ChannelInboundHandlerAdapte
             // Just use the maximum value we can represent via a Long.
             maxFieldSectionSize = Long.MAX_VALUE;
         }
-        qpackDecoder = new QpackDecoder(localSettings);
+        long maxTableCapacity = localSettings.getOrDefault(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0);
+        int maxBlockedStreams = toIntExact(localSettings.getOrDefault(HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 0));
+        qpackDecoder = new QpackDecoder(maxTableCapacity, maxBlockedStreams);
         qpackEncoder = new QpackEncoder();
         codecFactory = Http3FrameCodec.newFactory(qpackDecoder, maxFieldSectionSize, qpackEncoder);
         remoteControlStreamHandler =  new Http3ControlStreamOutboundHandler(server, localSettings,

--- a/src/main/java/io/netty/incubator/codec/http3/QpackUtil.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackUtil.java
@@ -21,6 +21,7 @@ import io.netty.util.internal.ConstantTimeUtils;
 import io.netty.util.internal.PlatformDependent;
 
 import static io.netty.util.internal.ObjectUtil.checkInRange;
+import static java.lang.Math.floorDiv;
 
 final class QpackUtil {
     private static final QpackException PREFIXED_INTEGER_TOO_LONG =
@@ -153,6 +154,18 @@ final class QpackUtil {
      */
     static boolean equalsVariableTime(CharSequence s1, CharSequence s2) {
         return AsciiString.contentEquals(s1, s2);
+    }
+
+    /**
+     * Calculate the MaxEntries based on
+     * <a href="https://www.rfc-editor.org/rfc/rfc9204.html#section-4.5.1.1">RFC9204 Section 4.5.1.1</a>.
+     *
+     * @param maxTableCapacity the maximum table capacity.
+     * @return maxEntries.
+     */
+    static long maxEntries(long maxTableCapacity) {
+        // MaxEntries = floor( MaxTableCapacity / 32 )
+        return floorDiv(maxTableCapacity, 32);
     }
 
     // Section 6.2. Literal Header Field Representation

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameCodecTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameCodecTest.java
@@ -101,7 +101,7 @@ public class Http3FrameCodecTest {
         maxTableCapacity = 1024L;
         settings.put(Http3SettingsFrame.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, maxTableCapacity);
         settings.put(Http3SettingsFrame.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, (long) maxBlockedStreams);
-        decoder = new QpackDecoder(settings);
+        decoder = new QpackDecoder(maxTableCapacity, maxBlockedStreams);
         decoder.setDynamicTableCapacity(maxTableCapacity);
         qpackEncoderHandler = new QpackEncoderHandler(maxTableCapacity, decoder);
         encoderStream = (EmbeddedQuicStreamChannel) parent.createStream(QuicStreamType.UNIDIRECTIONAL,

--- a/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamValidationHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3RequestStreamValidationHandlerTest.java
@@ -55,7 +55,7 @@ public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValid
 
     public Http3RequestStreamValidationHandlerTest() {
         super(true, true);
-        decoder = new QpackDecoder(new DefaultHttp3SettingsFrame());
+        decoder = new QpackDecoder(0, 0);
     }
 
     @Override

--- a/src/test/java/io/netty/incubator/codec/http3/Http3UnidirectionalStreamInboundHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3UnidirectionalStreamInboundHandlerTest.java
@@ -52,7 +52,7 @@ public class Http3UnidirectionalStreamInboundHandlerTest {
     private void setup(boolean server) {
         parent = new EmbeddedQuicChannel(server);
         qpackEncoder = new QpackEncoder();
-        qpackDecoder = new QpackDecoder(new DefaultHttp3SettingsFrame());
+        qpackDecoder = new QpackDecoder(0, 0);
         localControlStreamHandler = new Http3ControlStreamInboundHandler(server, null, qpackEncoder,
                 remoteControlStreamHandler);
         remoteControlStreamHandler = new Http3ControlStreamOutboundHandler(server, new DefaultHttp3SettingsFrame(),

--- a/src/test/java/io/netty/incubator/codec/http3/QpackDecoderTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackDecoderTest.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import static io.netty.incubator.codec.http3.Http3SettingsFrame.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY;
 import static io.netty.incubator.codec.http3.QpackDecoderStateSyncStrategy.ackEachInsert;
 import static io.netty.incubator.codec.http3.QpackUtil.MAX_UNSIGNED_INT;
-import static java.lang.Math.floorDiv;
 import static java.lang.Math.toIntExact;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -116,16 +115,17 @@ public class QpackDecoderTest {
     }
 
     private void setup(long capacity) throws QpackException {
+        long maxTableCapacity = MAX_UNSIGNED_INT;
         inserted = 0;
-        this.maxEntries = toIntExact(floorDiv(capacity, 32));
+        this.maxEntries = toIntExact(QpackUtil.maxEntries(maxTableCapacity));
         final DefaultHttp3SettingsFrame settings = new DefaultHttp3SettingsFrame();
-        settings.put(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, MAX_UNSIGNED_INT);
+        settings.put(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, maxTableCapacity);
         table = new QpackDecoderDynamicTable();
         EmbeddedQuicChannel parent = new EmbeddedQuicChannel(true);
         attributes = new QpackAttributes(parent, false);
         decoderStream = new EmbeddedQuicStreamChannel();
         attributes.decoderStream(decoderStream);
-        decoder = new QpackDecoder(settings, table, ackEachInsert());
+        decoder = new QpackDecoder(maxTableCapacity, 0, table, ackEachInsert());
         decoder.setDynamicTableCapacity(capacity);
     }
 


### PR DESCRIPTION
…ert count value

Motivation:

According to the required insert count encoding algorithm described in RFC-9204 "4.5.1.1. Required Insert Count" the max table capacity value should be used to encode maxEntries value:

```
Here MaxEntries is the maximum number of entries that the dynamic table can have.
The smallest entry has empty name and value strings and has the size of 32.
Hence, MaxEntries is calculated as:
   MaxEntries = floor( MaxTableCapacity / 32 )
```

MaxTableCapacity is the QPACK_MAX_TABLE_CAPACITY HTTP/3 setting value sent by the decoder:

```
To bound the memory requirements of the decoder, the decoder limits the maximum value the encoder
is permitted to set for the dynamic table capacity.
In HTTP/3, this limit is determined by the value of SETTINGS_QPACK_MAX_TABLE_CAPACITY
 sent by the decoder;
```

The implementations of QPack's encoder and decoder are using the current capacity value instead.

Modifications:

- Use maxTableCapacity to calculate maxEntries
- Fix tests

Result:

Fixes https://github.com/netty/netty-incubator-codec-http3/issues/254