### PR TITLE
Upgrade to latest netty-incubator-codec-quic release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <skipTests>false</skipTests>
     <netty.version>4.1.100.Final</netty.version>
     <netty.build.version>31</netty.build.version>
-    <netty.quic.version>0.0.51.Final</netty.quic.version>
+    <netty.quic.version>0.0.52.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <junit.version>5.9.0</junit.version>
     <release.gpg.keyname />

--- a/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicChannel.java
+++ b/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicChannel.java
@@ -34,6 +34,7 @@ import io.netty.incubator.codec.quic.QuicChannelConfig;
 import io.netty.incubator.codec.quic.QuicConnectionStats;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.incubator.codec.quic.QuicStreamType;
+import io.netty.incubator.codec.quic.QuicTransportParameters;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
@@ -148,6 +149,11 @@ final class EmbeddedQuicChannel extends EmbeddedChannel implements QuicChannel {
 
     public EmbeddedQuicStreamChannel localControlStream() {
         return (EmbeddedQuicStreamChannel) Http3.getLocalControlStream(this);
+    }
+
+    @Override
+    public QuicTransportParameters peerTransportParameters() {
+        return null;
     }
 
     Collection<Integer> closeErrorCodes() {


### PR DESCRIPTION
Motivation:

Let's update to the latest release of netty-incubator-codec-quic

Modifications:

Upgrade to 0.0.52.Final

Result:

Use latest release