### PR TITLE
QPACK: Allow stream cancellation even if the dynamic table was config…

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/QpackEncoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackEncoder.java
@@ -163,7 +163,12 @@ final class QpackEncoder {
      * @param streamId which is cancelled.
      */
     void streamCancellation(long streamId) throws QpackException {
-        assert streamSectionTrackers != null;
+        // If a configureDynamicTable(...) was called with a maxTableCapacity of 0 we will have not instanced
+        // streamSectionTrackers. The remote peer might still send a stream cancellation for a stream, while it
+        // is optional. See https://www.rfc-editor.org/rfc/rfc9204.html#section-2.2.2.2
+        if (streamSectionTrackers == null) {
+            return;
+        }
         final Queue<Indices> tracker = streamSectionTrackers.remove(streamId);
         if (tracker != null) {
             for (;;) {


### PR DESCRIPTION
…ured with max capacity of 0

Motivation:

It is fine to send stream cancellations even if the dynamic table had a capacity of 0 and so was disabled. We didn't follow the spec here and did case a NPE if we received a stream cancellation after the table was configured with capacity of 0.

Modifications:

- Allow stream cancellation if if the table capacity is 0
- Add unit test

Result:

Fixes https://github.com/netty/netty-incubator-codec-http3/issues/261 and https://github.com/netty/netty-incubator-codec-http3/issues/252