### PR TITLE
QPACK: Handle it as an error if we receive an ack for a section for w…

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/QpackEncoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackEncoder.java
@@ -151,9 +151,12 @@ final class QpackEncoder {
         if (tracker.isEmpty()) {
             streamSectionTrackers.remove(streamId);
         }
-        if (dynamicTableIndices != null) {
-            dynamicTableIndices.forEach(dynamicTable::acknowledgeInsertCount);
+
+        if (dynamicTableIndices == null) {
+            throw INVALID_SECTION_ACKNOWLEDGMENT;
         }
+
+        dynamicTableIndices.forEach(dynamicTable::acknowledgeInsertCount);
     }
 
     /**


### PR DESCRIPTION
…hich we have no indices.

Motivation:

We should treat it as an error if we receive an ack for a section for which we have no indices.

Modifications:

Throw exception if we receive an ack for a section that has no indices

Result:

Correctly handle acks