### PR TITLE
QPACK: Don't update known received count when stream is cancelled.

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/QpackEncoder.java
+++ b/src/main/java/io/netty/incubator/codec/http3/QpackEncoder.java
@@ -156,7 +156,7 @@ final class QpackEncoder {
             throw INVALID_SECTION_ACKNOWLEDGMENT;
         }
 
-        dynamicTableIndices.forEach(dynamicTable::acknowledgeInsertCount);
+        dynamicTableIndices.forEach(dynamicTable::acknowledgeInsertCountOnAck);
     }
 
     /**
@@ -179,7 +179,7 @@ final class QpackEncoder {
                 if (dynamicTableIndices == null) {
                     break;
                 }
-                dynamicTableIndices.forEach(dynamicTable::acknowledgeInsertCount);
+                dynamicTableIndices.forEach(dynamicTable::acknowledgeInsertCountOnCancellation);
             }
         }
     }

--- a/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDynamicTableTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDynamicTableTest.java
@@ -161,7 +161,7 @@ public class QpackEncoderDynamicTableTest {
 
         final int idx = addAndValidateHeader(table, fooBarHeader);
         table.addReferenceToEntry(fooBarHeader.name, fooBarHeader.value, idx);
-        table.acknowledgeInsertCount(idx);
+        table.acknowledgeInsertCountOnAck(idx);
 
         assertThat("Unexpected known received count.", table.encodedKnownReceivedCount(), is(2));
     }
@@ -176,10 +176,10 @@ public class QpackEncoderDynamicTableTest {
         final int idx2 = addAndValidateHeader(table, fooBarHeader);
         table.addReferenceToEntry(fooBarHeader.name, fooBarHeader.value, idx2);
 
-        table.acknowledgeInsertCount(idx2);
+        table.acknowledgeInsertCountOnAck(idx2);
         assertThat("Unexpected known received count.", table.encodedKnownReceivedCount(), is(3));
 
-        table.acknowledgeInsertCount(idx1);
+        table.acknowledgeInsertCountOnAck(idx1);
         assertThat("Unexpected known received count.", table.encodedKnownReceivedCount(), is(3)); // already acked
     }
 
@@ -192,12 +192,12 @@ public class QpackEncoderDynamicTableTest {
         table.addReferenceToEntry(fooBar3Header.name, fooBar3Header.value, idx1);
         table.addReferenceToEntry(fooBar3Header.name, fooBar3Header.value, idx1);
 
-        table.acknowledgeInsertCount(idx1);
+        table.acknowledgeInsertCountOnAck(idx1);
 
         // first entry still active
         assertThat("Header added", addHeader(table, fooBar2Header), lessThan(0));
 
-        table.acknowledgeInsertCount(idx1);
+        table.acknowledgeInsertCountOnAck(idx1);
         verifyTableEmpty(table);
         addAndValidateHeader(table, fooBarHeader);
     }
@@ -229,7 +229,7 @@ public class QpackEncoderDynamicTableTest {
     private int addValidateAndAckHeader(QpackEncoderDynamicTable table, QpackHeaderField header) throws Exception {
         final int addedIdx = addAndValidateHeader(table, header);
         table.addReferenceToEntry(header.name, header.value, addedIdx);
-        table.acknowledgeInsertCount(addedIdx);
+        table.acknowledgeInsertCountOnAck(addedIdx);
         return addedIdx;
     }
 


### PR DESCRIPTION
Motivation:

We dont know if everything was sucessful decoded so we should not update the known received count on stream cancellation

Modifications:

Don't update the known received count on cancellation

Result:

Correct behaviour during cancellation