### PR TITLE
Remove dependency on vintage engine as we only use junit5 APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -414,12 +414,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <version>${junit.version}</version>


### PR DESCRIPTION
Motivation:

The whole project was migrated to junit5 so there is not need for the extra dependency on the vintage engine

Modifications:

Remove dependency

Result:

Cleanup