### PR TITLE
Update to new netty-incubator-codec-quic release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <skipTests>false</skipTests>
     <netty.version>4.1.104.Final</netty.version>
     <netty.build.version>31</netty.build.version>
-    <netty.quic.version>0.0.54.Final</netty.quic.version>
+    <netty.quic.version>0.0.55.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <junit.version>5.9.0</junit.version>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

A new netty-incubator-codec-quic release was done

Modifications:

Update to 0.0.55.Final

Result:

Use latest netty-incubator-codec-quic version as dependency