### PR TITLE
Drain queued writes when Http3FrameCodec is removed

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameCodec.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameCodec.java
@@ -110,6 +110,15 @@ final class Http3FrameCodec extends ByteToMessageDecoder implements ChannelOutbo
     }
 
     @Override
+    protected void handlerRemoved0(ChannelHandlerContext ctx) throws Exception {
+        if (writeResumptionListener != null) {
+            // drain everything so we are sure we never leak anything.
+            writeResumptionListener.drain();
+        }
+        super.handlerRemoved0(ctx);
+    }
+
+    @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         ByteBuf buffer;
         if (msg instanceof QuicStreamFrame) {


### PR DESCRIPTION
Motivation:

We need to ensure we drain all the previous queued writes when the Http3FrameCodec is removed. Failing to do so might result in leaks and missing writes.

Modifications:

Override handlerRemoved0(...) and drain all writes

Result:

No more possible leaks when handler is removed