### PR TITLE
Let GC collect localSettings as soon as possible

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3ClientConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ClientConnectionHandler.java
@@ -21,8 +21,6 @@ import io.netty.incubator.codec.quic.QuicStreamChannel;
 
 import java.util.function.LongFunction;
 
-import static io.netty.incubator.codec.http3.Http3SettingsFrame.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY;
-
 public final class Http3ClientConnectionHandler extends Http3ConnectionHandler {
 
     private final LongFunction<ChannelHandler> pushStreamHandlerFactory;
@@ -69,8 +67,7 @@ public final class Http3ClientConnectionHandler extends Http3ConnectionHandler {
 
     @Override
     void initUnidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel streamChannel) {
-        final Long maxTableCapacity = remoteControlStreamHandler.localSettings()
-                .get(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY);
+        final long maxTableCapacity = maxTableCapacity();
         streamChannel.pipeline().addLast(
                 new Http3UnidirectionalStreamInboundClientHandler(codecFactory,
                         localControlStreamHandler, remoteControlStreamHandler,

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ConnectionHandler.java
@@ -43,6 +43,8 @@ public abstract class Http3ConnectionHandler extends ChannelInboundHandlerAdapte
     final QpackEncoder qpackEncoder;
     private boolean controlStreamCreationInProgress;
 
+    final long maxTableCapacity;
+
     /**
      * Create a new instance.
      * @param server                                {@code true} if server-side, {@code false} otherwise.
@@ -71,7 +73,7 @@ public abstract class Http3ConnectionHandler extends ChannelInboundHandlerAdapte
             // Just use the maximum value we can represent via a Long.
             maxFieldSectionSize = Long.MAX_VALUE;
         }
-        long maxTableCapacity = localSettings.getOrDefault(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0);
+        this.maxTableCapacity = localSettings.getOrDefault(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0);
         int maxBlockedStreams = toIntExact(localSettings.getOrDefault(HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 0));
         qpackDecoder = new QpackDecoder(maxTableCapacity, maxBlockedStreams);
         qpackEncoder = new QpackEncoder();
@@ -192,6 +194,10 @@ public abstract class Http3ConnectionHandler extends ChannelInboundHandlerAdapte
      * @param streamChannel the {@link QuicStreamChannel}.
      */
     abstract void initUnidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel streamChannel);
+
+    long maxTableCapacity() {
+        return maxTableCapacity;
+    }
 
     /**
      * Always returns {@code false} as it keeps state.

--- a/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3ServerConnectionHandler.java
@@ -81,8 +81,7 @@ public final class Http3ServerConnectionHandler extends Http3ConnectionHandler {
 
     @Override
     void initUnidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel streamChannel) {
-        final Long maxTableCapacity = remoteControlStreamHandler.localSettings()
-                .get(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY);
+        final long maxTableCapacity = maxTableCapacity();
         streamChannel.pipeline().addLast(
                 new Http3UnidirectionalStreamInboundServerHandler(codecFactory,
                         localControlStreamHandler, remoteControlStreamHandler,


### PR DESCRIPTION
Motivation:

There is no need to hold a reference to the localSettings after we sent it as we only do once.

Modifications:

- Null out localSettings as soon as possible to save memory

Result:

Less memory usage in long living connections