### PR TITLE
Update java 8 version

### DIFF
--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -18,7 +18,7 @@ WORKDIR $SOURCE_DIR
 # Downloading and installing SDKMAN!
 RUN curl -s "https://get.sdkman.io" | bash
 
-ARG java_version="8.0.322-zulu"
+ARG java_version="8.0.402-zulu"
 ENV JAVA_VERSION $java_version
 
 # Installing Java removing some unnecessary SDKMAN files

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-http3-centos7:centos-7-1.8
     build:
       args:
-        java_version : "8.0.392-zulu"
+        java_version : "8.0.402-zulu"
 
   build:
     image: netty-codec-http3-centos7:centos-7-1.8


### PR DESCRIPTION
Motivation:

We should use the latest java release on our CI

Modifications:

Update to 8.0.402-zulu

Result:

Use the latest java 8 release