### PR TITLE
Upgrade to netty-incubator-codec-quic 0.0.62.Final to fix re-ordering…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <skipTests>false</skipTests>
     <netty.version>4.1.108.Final</netty.version>
     <netty.build.version>31</netty.build.version>
-    <netty.quic.version>0.0.60.Final</netty.quic.version>
+    <netty.quic.version>0.0.62.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <junit.version>5.9.0</junit.version>
     <release.gpg.keyname />

--- a/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicChannel.java
+++ b/src/test/java/io/netty/incubator/codec/http3/EmbeddedQuicChannel.java
@@ -32,6 +32,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.incubator.codec.quic.QuicChannel;
 import io.netty.incubator.codec.quic.QuicChannelConfig;
 import io.netty.incubator.codec.quic.QuicConnectionAddress;
+import io.netty.incubator.codec.quic.QuicConnectionPathStats;
 import io.netty.incubator.codec.quic.QuicConnectionStats;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.incubator.codec.quic.QuicStreamType;
@@ -167,6 +168,12 @@ final class EmbeddedQuicChannel extends EmbeddedChannel implements QuicChannel {
     public Future<QuicConnectionStats> collectStats(Promise<QuicConnectionStats> promise) {
         return promise.setFailure(
                 new UnsupportedOperationException("Collect stats not supported for embedded channel."));
+    }
+
+    @Override
+    public Future<QuicConnectionPathStats> collectPathStats(int i, Promise<QuicConnectionPathStats> promise) {
+        return promise.setFailure(
+                new UnsupportedOperationException("Collect path stats not supported for embedded channel."));
     }
 
     public EmbeddedQuicStreamChannel localControlStream() {


### PR DESCRIPTION
… issues

Motivation:

netty-incubator-codec-quic 0.0.62.Final fixed a bug which could cause re-ordering of writes and so corrupted data.

Modifications:

Upgrade and so fix possible data corruption

Result:

No more out-of-order writes