### PR TITLE
Include more details in the UnsupportedMessageTypeException when thrown

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodec.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodec.java
@@ -134,7 +134,7 @@ public final class Http3FrameToHttpObjectCodec extends Http3RequestStreamInbound
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         if (!(msg instanceof HttpObject)) {
-            throw new UnsupportedMessageTypeException();
+            throw new UnsupportedMessageTypeException(msg, HttpObject.class);
         }
         // 100-continue is typically a FullHttpResponse, but the decoded
         // Http3HeadersFrame should not handles as a end of stream.

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
@@ -32,6 +32,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.DuplexChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.codec.EncoderException;
+import io.netty.handler.codec.UnsupportedMessageTypeException;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpContent;
@@ -85,6 +86,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -1068,5 +1070,14 @@ data.release();
         } finally {
             group.shutdownGracefully();
         }
+    }
+
+    @Test
+    public void testUnsupportedIncludeSomeDetails() {
+        EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
+        UnsupportedMessageTypeException ex = assertThrows(
+                UnsupportedMessageTypeException.class, () -> ch.writeOutbound("unsupported"));
+        assertNotNull(ex.getMessage());
+        assertFalse(ch.finish());
     }
 }


### PR DESCRIPTION
Motivation:

Let's include some more details about why this exception was thrown and what we expected.

Modifications:

Use other constructor which will provide some useful informations

Result:

Easier to debug