### PR TITLE
Upgrade to netty-incubator-codec-quic 0.0.63.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <skipTests>false</skipTests>
     <netty.version>4.1.110.Final</netty.version>
     <netty.build.version>31</netty.build.version>
-    <netty.quic.version>0.0.62.Final</netty.quic.version>
+    <netty.quic.version>0.0.63.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <junit.version>5.9.0</junit.version>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

We released a new quic version

Modifications:

Upgrade to latest version

Result:

Use latest quic release