### PR TITLE
Upgrade netty and quic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
   <properties>
     <javaModuleName>io.netty.incubator.codec.http3</javaModuleName>
     <skipTests>false</skipTests>
-    <netty.version>4.1.110.Final</netty.version>
+    <netty.version>4.1.111.Final</netty.version>
     <netty.build.version>31</netty.build.version>
-    <netty.quic.version>0.0.63.Final</netty.quic.version>
+    <netty.quic.version>0.0.64.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <junit.version>5.9.0</junit.version>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

There were new netty and quic releases

Modifications:

Update both dependencies

Result:

Use latest versions