### PR TITLE
Use --release 8 during compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,12 +89,13 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.13.0</version>
         <configuration>
           <compilerVersion>1.8</compilerVersion>
           <fork>true</fork>
           <source>1.8</source>
           <target>1.8</target>
+          <release>8</release>
           <debug>true</debug>
           <optimize>true</optimize>
           <showDeprecation>true</showDeprecation>


### PR DESCRIPTION
Motivation:

We should use --release 8 during compilation to ensure we always end up with the correct java version that is required.

Modifications:

- Upgrade compiler plugin so the release flag is only used when compiling with java9+
- Specify release flag

Result:

Always end up with the correct bytecode