### PR TITLE
Update java versions to latest release

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -4,8 +4,8 @@
 cd /path/to/source/
 ```
 
-## centos 8 with java 8
+## centos 7 with java 8
 
 ```
-docker-compose -f docker/docker-compose.centos-8.yaml -f docker/docker-compose.centos-8.18.yaml run build
+docker-compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run build
 ```

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-http3-centos7:centos-7-1.8
     build:
       args:
-        java_version : "8.0.402-zulu"
+        java_version : "8.0.412-zulu"
 
   build:
     image: netty-codec-http3-centos7:centos-7-1.8


### PR DESCRIPTION
Motivation:

The used java versions in our docker-compose file were outdated

Modifications:

Update all versions to latest release

Result:

Use latest versions on CI