### PR TITLE
Upgrade java to latest patch releases

### DIFF
--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-http3-centos7:centos-7-1.8
     build:
       args:
-        java_version : "8.0.412-zulu"
+        java_version : "8.0.422-zulu"
 
   build:
     image: netty-codec-http3-centos7:centos-7-1.8


### PR DESCRIPTION
Motivation:

We are behind on the java patch releases used during build

Modifications:

Bump up java versions in docker-compose files

Result:

Use latest java versions