### PR TITLE
Replace docker-compose with docker compose

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -44,10 +44,10 @@ jobs:
             build-cache-m2-repository-
 
       - name: Build docker image
-        run: docker-compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml build
+        run: docker compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml build
 
       - name: Execute project build without leak detection
-        run: docker-compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run build | tee build-leak.output
+        run: docker compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run build | tee build-leak.output
 
       - name: Checking for test failures
         run: ./.github/scripts/check_build_result.sh build-leak.output

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -53,7 +53,7 @@ jobs:
             deploy-cache-m2-repository-
 
       - name: Build docker image
-        run: docker-compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml build
+        run: docker compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml build
 
       - name: Deploy project snapshot to sonatype
-        run: docker-compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run deploy
+        run: docker compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run deploy

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -62,10 +62,10 @@ jobs:
             pr-cache-m2-repository-
 
       - name: Build docker image
-        run: docker-compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml build
+        run: docker compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml build
 
       - name: Execute project build with leak detection
-        run: docker-compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run build-leak | tee build-leak.output
+        run: docker compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run build-leak | tee build-leak.output
 
       - name: Checking for test failures
         run: ./.github/scripts/check_build_result.sh build-leak.output


### PR DESCRIPTION
Motivation:

docker-compose is no more and you should use docker compose

Modifications:

Replace docker-compose with docker compose

Result:

Build works again