### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
   <properties>
     <javaModuleName>io.netty.incubator.codec.http3</javaModuleName>
     <skipTests>false</skipTests>
-    <netty.version>4.1.114.Final</netty.version>
+    <netty.version>4.1.115.Final</netty.version>
     <netty.build.version>31</netty.build.version>
-    <netty.quic.version>0.0.67.Final</netty.quic.version>
+    <netty.quic.version>0.0.68.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <junit.version>5.9.0</junit.version>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

We used an outdated version of netty and netty-incubator-codec-quic

Modifications:

- Update to netty 4.1.115.Final
- Update to netty-incubator-codec-quic 0.0.68.Final

Result:

Update dependencies