### PR TITLE
Update to netty-incubator-codec-quic 0.0.69.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <skipTests>false</skipTests>
     <netty.version>4.1.115.Final</netty.version>
     <netty.build.version>31</netty.build.version>
-    <netty.quic.version>0.0.68.Final</netty.quic.version>
+    <netty.quic.version>0.0.69.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <junit.version>5.9.0</junit.version>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

A new quic codec release is out

Modifications:

Update to 0.0.69.Final

Result:

Use latest release