### PR TITLE
Fix reserved key confusion caused by unchecked cast

### DIFF
--- a/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
+++ b/src/main/java/io/netty/incubator/codec/http3/Http3CodecUtils.java
@@ -94,17 +94,9 @@ final class Http3CodecUtils {
     }
 
     static boolean isReservedHttp2Setting(long key) {
-        switch ((int) key) {
-            // Reserved types that were used in HTTP/2
-            // https://tools.ietf.org/html/draft-ietf-quic-http-32#section-11.2.2
-            case 0x2:
-            case 0x3:
-            case 0x4:
-            case 0x5:
-                return true;
-            default:
-                return false;
-        }
+        // Reserved types that were used in HTTP/2
+        // https://tools.ietf.org/html/draft-ietf-quic-http-32#section-11.2.2
+        return 0x2L <= key && key <= 0x5L;
     }
 
     /**


### PR DESCRIPTION
Motivation:
In the method `Http3CodecUtils.isReservedHttp2Setting` the long key parameter is user-supplied data, so we can't blindly cast it to an int. It may contain higher-order bits which would be truncated off, and thus leading us to confuse the value with a reserved key.

Modification:
Remove the int-cast and compare the value directly with literal long-values.

Result:
Avoid confusion from a truncated int cast of a user-supplied value.