### PR TITLE
Update netty and netty-incubator-codec-quic to the latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
   <properties>
     <javaModuleName>io.netty.incubator.codec.http3</javaModuleName>
     <skipTests>false</skipTests>
-    <netty.version>4.1.118.Final</netty.version>
+    <netty.version>4.1.121.Final</netty.version>
     <netty.build.version>31</netty.build.version>
-    <netty.quic.version>0.0.71.Final</netty.quic.version>
+    <netty.quic.version>0.0.72.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <junit.version>5.9.0</junit.version>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

We had new release of netty and neetty-incubator-codec quic

Modifications:

Update to latest releases

Result:

Use latest releases as dependency