### PR TITLE
Migrate to using maven central

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -36,9 +36,9 @@ jobs:
         with:
           servers: |
             [{
-                "id": "sonatype-nexus-snapshots",
-                "username": "${{ secrets.SONATYPE_USERNAME }}",
-                "password": "${{ secrets.SONATYPE_PASSWORD }}"
+                "id": "central",
+                "username": "${{ secrets.MAVEN_CENTRAL_USERNAME }}",
+                "password": "${{ secrets.MAVEN_CENTRAL_PASSWORD }}"
             }]
 
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -58,9 +58,9 @@ jobs:
         with:
           servers: |
             [{
-                "id": "sonatype-nexus",
-                "username": "${{ secrets.SONATYPE_USERNAME }}",
-                "password": "${{ secrets.SONATYPE_PASSWORD }}"
+                "id": "central",
+                "username": "${{ secrets.MAVEN_CENTRAL_USERNAME }}",
+                "password": "${{ secrets.MAVEN_CENTRAL_PASSWORD }}"
             }]
 
       # Cache .m2/repository

--- a/pom.xml
+++ b/pom.xml
@@ -252,16 +252,13 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.13</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
         <extensions>true</extensions>
         <configuration>
-          <serverId>sonatype-nexus</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <!-- Automatically release the artifacts after the verification was complete -->
-          <autoReleaseAfterClose>false</autoReleaseAfterClose>
-          <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
+          <publishingServerId>central</publishingServerId>
+          <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Motivation:

OSSRH is deprecated and will be shut down soon. Let's switch to using maven central

Modifications:

- Replace old plugin with central-publishing-maven-plugin
- Adjust workflow to setup the right token / password

Result:

Snapshot deployments and release works again