### PR TITLE
Replace hamcrest usage by assert4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,9 +437,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <version>1.3</version>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.20.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3FrameToHttpObjectCodecTest.java
@@ -79,15 +79,12 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.not;
+import static com.google.common.base.Predicates.instanceOf;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -99,7 +96,7 @@ public class Http3FrameToHttpObjectCodecTest {
         assertTrue(ch.writeOutbound(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)));
 
         Http3HeadersFrame headersFrame = ch.readOutbound();
-        assertThat(headersFrame.headers().status().toString(), is("200"));
+        assertEquals("200", headersFrame.headers().status().toString());
         assertTrue(ch.isOutputShutdown());
 
         assertFalse(ch.finish());
@@ -112,10 +109,10 @@ public class Http3FrameToHttpObjectCodecTest {
                 HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE)));
 
         Http3HeadersFrame headersFrame = ch.readOutbound();
-        assertThat(headersFrame.headers().status().toString(), is("100"));
+        assertEquals("100", headersFrame.headers().status().toString());
         assertFalse(ch.isOutputShutdown());
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -134,11 +131,11 @@ public class Http3FrameToHttpObjectCodecTest {
         assertTrue(ch.writeOutbound(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, hello)));
 
         Http3HeadersFrame headersFrame = ch.readOutbound();
-        assertThat(headersFrame.headers().status().toString(), is("200"));
+        assertEquals("200", headersFrame.headers().status().toString());
 
         Http3DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
         } finally {
             dataFrame.release();
         }
@@ -156,10 +153,10 @@ public class Http3FrameToHttpObjectCodecTest {
         assertTrue(ch.writeOutbound(response));
 
         Http3HeadersFrame headersFrame = ch.readOutbound();
-        assertThat(headersFrame.headers().status().toString(), is("200"));
+        assertEquals("200", headersFrame.headers().status().toString());
 
         Http3HeadersFrame trailersFrame = ch.readOutbound();
-        assertThat(trailersFrame.headers().get("key").toString(), is("value"));
+        assertEquals("value", trailersFrame.headers().get("key").toString());
         assertTrue(ch.isOutputShutdown());
 
         assertFalse(ch.finish());
@@ -175,17 +172,17 @@ public class Http3FrameToHttpObjectCodecTest {
         assertTrue(ch.writeOutbound(response));
 
         Http3HeadersFrame headersFrame = ch.readOutbound();
-        assertThat(headersFrame.headers().status().toString(), is("200"));
+        assertEquals("200", headersFrame.headers().status().toString());
 
         Http3DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
         } finally {
             dataFrame.release();
         }
 
         Http3HeadersFrame trailersFrame = ch.readOutbound();
-        assertThat(trailersFrame.headers().get("key").toString(), is("value"));
+        assertEquals("value", trailersFrame.headers().get("key").toString());
         assertTrue(ch.isOutputShutdown());
 
         assertFalse(ch.finish());
@@ -198,10 +195,10 @@ public class Http3FrameToHttpObjectCodecTest {
         assertTrue(ch.writeOutbound(response));
 
         Http3HeadersFrame headersFrame = ch.readOutbound();
-        assertThat(headersFrame.headers().status().toString(), is("200"));
+        assertEquals("200", headersFrame.headers().status().toString());
         assertFalse(ch.isOutputShutdown());
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -214,13 +211,13 @@ public class Http3FrameToHttpObjectCodecTest {
 
         Http3DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
             assertFalse(ch.isOutputShutdown());
         } finally {
             dataFrame.release();
         }
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -232,7 +229,7 @@ public class Http3FrameToHttpObjectCodecTest {
         assertTrue(ch.isOutputShutdown());
         Http3DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().readableBytes(), is(0));
+            assertEquals(0, dataFrame.content().readableBytes());
         } finally {
             dataFrame.release();
         }
@@ -249,7 +246,7 @@ public class Http3FrameToHttpObjectCodecTest {
 
         Http3DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
         } finally {
             dataFrame.release();
         }
@@ -269,13 +266,13 @@ public class Http3FrameToHttpObjectCodecTest {
 
         Http3DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
         } finally {
             dataFrame.release();
         }
 
         Http3HeadersFrame headerFrame = ch.readOutbound();
-        assertThat(headerFrame.headers().get("key").toString(), is("value"));
+        assertEquals("value", headerFrame.headers().get("key").toString());
         assertTrue(ch.isOutputShutdown());
 
         assertFalse(ch.finish());
@@ -291,13 +288,13 @@ public class Http3FrameToHttpObjectCodecTest {
         assertTrue(ch.writeInbound(new DefaultHttp3HeadersFrame(headers)));
 
         HttpRequest request = ch.readInbound();
-        assertThat(request.uri(), is("/"));
-        assertThat(request.method(), is(HttpMethod.GET));
-        assertThat(request.protocolVersion(), is(HttpVersion.HTTP_1_1));
+        assertEquals("/", request.uri());
+        assertEquals(HttpMethod.GET, request.method());
+        assertEquals(HttpVersion.HTTP_1_1, request.protocolVersion());
         assertFalse(request instanceof FullHttpRequest);
         assertTrue(HttpUtil.isTransferEncodingChunked(request));
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -312,13 +309,13 @@ public class Http3FrameToHttpObjectCodecTest {
         assertTrue(ch.writeInbound(new DefaultHttp3HeadersFrame(headers)));
 
         HttpRequest request = ch.readInbound();
-        assertThat(request.uri(), is("/"));
-        assertThat(request.method(), is(HttpMethod.GET));
-        assertThat(request.protocolVersion(), is(HttpVersion.HTTP_1_1));
+        assertEquals("/", request.uri());
+        assertEquals(HttpMethod.GET, request.method());
+        assertEquals(HttpVersion.HTTP_1_1, request.protocolVersion());
         assertFalse(request instanceof FullHttpRequest);
         assertFalse(HttpUtil.isTransferEncodingChunked(request));
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -332,14 +329,14 @@ public class Http3FrameToHttpObjectCodecTest {
 
         LastHttpContent trailers = ch.readInbound();
         try {
-            assertThat(trailers.content().readableBytes(), is(0));
-            assertThat(trailers.trailingHeaders().get("key"), is("value"));
+            assertEquals(0, trailers.content().readableBytes());
+            assertEquals("value", trailers.trailingHeaders().get("key"));
             assertFalse(trailers instanceof FullHttpRequest);
         } finally {
             trailers.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -351,13 +348,13 @@ public class Http3FrameToHttpObjectCodecTest {
 
         HttpContent content = ch.readInbound();
         try {
-            assertThat(content.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", content.content().toString(CharsetUtil.UTF_8));
             assertFalse(content instanceof LastHttpContent);
         } finally {
             content.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -369,7 +366,7 @@ public class Http3FrameToHttpObjectCodecTest {
 
         HttpContent content = ch.readInbound();
         try {
-            assertThat(content.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", content.content().toString(CharsetUtil.UTF_8));
         } finally {
             content.release();
         }
@@ -382,7 +379,7 @@ public class Http3FrameToHttpObjectCodecTest {
             last.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -395,9 +392,9 @@ public class Http3FrameToHttpObjectCodecTest {
         Http3HeadersFrame headersFrame = ch.readOutbound();
         Http3Headers headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("https"));
-        assertThat(headers.method().toString(), is("GET"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        assertEquals("https", headers.scheme().toString());
+        assertEquals("GET", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
         assertTrue(ch.isOutputShutdown());
 
         assertFalse(ch.finish());
@@ -413,13 +410,13 @@ public class Http3FrameToHttpObjectCodecTest {
         Http3HeadersFrame headersFrame = ch.readOutbound();
         Http3Headers headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("https"));
-        assertThat(headers.method().toString(), is("PUT"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        assertEquals("https", headers.scheme().toString());
+        assertEquals("PUT", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
 
         Http3DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
         } finally {
             dataFrame.release();
         }
@@ -441,12 +438,12 @@ public class Http3FrameToHttpObjectCodecTest {
         Http3HeadersFrame headersFrame = ch.readOutbound();
         Http3Headers headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("https"));
-        assertThat(headers.method().toString(), is("PUT"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        assertEquals("https", headers.scheme().toString());
+        assertEquals("PUT", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
 
         Http3HeadersFrame trailersFrame = ch.readOutbound();
-        assertThat(trailersFrame.headers().get("key").toString(), is("value"));
+        assertEquals("value", trailersFrame.headers().get("key").toString());
 
         assertTrue(ch.isOutputShutdown());
         assertFalse(ch.finish());
@@ -466,19 +463,19 @@ public class Http3FrameToHttpObjectCodecTest {
         Http3HeadersFrame headersFrame = ch.readOutbound();
         Http3Headers headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("https"));
-        assertThat(headers.method().toString(), is("PUT"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        assertEquals("https", headers.scheme().toString());
+        assertEquals("PUT", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
 
         Http3DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
         } finally {
             dataFrame.release();
         }
 
         Http3HeadersFrame trailersFrame = ch.readOutbound();
-        assertThat(trailersFrame.headers().get("key").toString(), is("value"));
+        assertEquals("value", trailersFrame.headers().get("key").toString());
 
         assertTrue(ch.isOutputShutdown());
         assertFalse(ch.finish());
@@ -493,12 +490,12 @@ public class Http3FrameToHttpObjectCodecTest {
         Http3HeadersFrame headersFrame = ch.readOutbound();
         Http3Headers headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("https"));
-        assertThat(headers.method().toString(), is("GET"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        assertEquals("https", headers.scheme().toString());
+        assertEquals("GET", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
         assertFalse(ch.isOutputShutdown());
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -511,12 +508,12 @@ public class Http3FrameToHttpObjectCodecTest {
 
         Http3DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
         } finally {
             dataFrame.release();
         }
         assertFalse(ch.isOutputShutdown());
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -528,7 +525,7 @@ public class Http3FrameToHttpObjectCodecTest {
         assertTrue(ch.isOutputShutdown());
         Http3DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().readableBytes(), is(0));
+            assertEquals(0, dataFrame.content().readableBytes());
         } finally {
             dataFrame.release();
         }
@@ -545,7 +542,7 @@ public class Http3FrameToHttpObjectCodecTest {
 
         Http3DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
         } finally {
             dataFrame.release();
         }
@@ -563,7 +560,7 @@ public class Http3FrameToHttpObjectCodecTest {
         assertTrue(ch.writeOutbound(trailers));
 
         Http3HeadersFrame headerFrame = ch.readOutbound();
-        assertThat(headerFrame.headers().get("key").toString(), is("value"));
+        assertEquals("value", headerFrame.headers().get("key").toString());
 
         assertTrue(ch.isOutputShutdown());
         assertFalse(ch.finish());
@@ -580,13 +577,13 @@ public class Http3FrameToHttpObjectCodecTest {
 
         Http3DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
         } finally {
             dataFrame.release();
         }
 
         Http3HeadersFrame headerFrame = ch.readOutbound();
-        assertThat(headerFrame.headers().get("key").toString(), is("value"));
+        assertEquals("value", headerFrame.headers().get("key").toString());
 
         assertTrue(ch.isOutputShutdown());
         assertFalse(ch.finish());
@@ -603,9 +600,9 @@ public class Http3FrameToHttpObjectCodecTest {
         Http3HeadersFrame headersFrame = ch.readOutbound();
         Http3Headers headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("https"));
-        assertThat(headers.method().toString(), is("GET"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        assertEquals("https", headers.scheme().toString());
+        assertEquals("GET", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
         assertTrue(ch.isOutputShutdown());
 
         assertFalse(ch.finish());
@@ -624,14 +621,14 @@ public class Http3FrameToHttpObjectCodecTest {
         Http3HeadersFrame headersFrame = ch.readOutbound();
         Http3Headers headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("https"));
-        assertThat(headers.method().toString(), is("GET"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        assertEquals("https", headers.scheme().toString());
+        assertEquals("GET", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
         assertTrue(ch.isOutputShutdown());
 
         Http3DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().readableBytes(), is(0));
+            assertEquals(0, dataFrame.content().readableBytes());
         } finally {
             dataFrame.release();
         }
@@ -653,9 +650,9 @@ public class Http3FrameToHttpObjectCodecTest {
         Http3HeadersFrame headersFrame = ch.readOutbound();
         Http3Headers headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("https"));
-        assertThat(headers.method().toString(), is("GET"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        assertEquals("https", headers.scheme().toString());
+        assertEquals("GET", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
         assertTrue(ch.isOutputShutdown());
 
         Http3DataFrame dataFrame = ch.readOutbound();
@@ -680,9 +677,9 @@ public class Http3FrameToHttpObjectCodecTest {
         Http3HeadersFrame headersFrame = ch.readOutbound();
         Http3Headers headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("https"));
-        assertThat(headers.method().toString(), is("GET"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        assertEquals("https", headers.scheme().toString());
+        assertEquals("GET", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
         assertTrue(ch.isOutputShutdown());
 
         Http3DataFrame dataFrame = ch.readOutbound();
@@ -705,10 +702,10 @@ public class Http3FrameToHttpObjectCodecTest {
         Http3HeadersFrame headersFrame = ch.readOutbound();
         Http3Headers headers = headersFrame.headers();
         Http3DataFrame data = ch.readOutbound();
-data.release();
-        assertThat(headers.scheme().toString(), is("https"));
-        assertThat(headers.method().toString(), is("POST"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        data.release();
+        assertEquals("https", headers.scheme().toString());
+        assertEquals("POST", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
         assertTrue(ch.isOutputShutdown());
 
         assertFalse(ch.finish());
@@ -793,21 +790,21 @@ data.release();
 
         if (headers) {
             Http3HeadersFrame headersFrame = ch.readOutbound();
-            assertThat(headersFrame.headers().scheme().toString(), is("https"));
-            assertThat(headersFrame.headers().method().toString(), is("POST"));
-            assertThat(headersFrame.headers().path().toString(), is("/foo"));
+            assertEquals("https", headersFrame.headers().scheme().toString());
+            assertEquals("POST", headersFrame.headers().method().toString());
+            assertEquals("/foo", headersFrame.headers().path().toString());
         }
         if (nonEmptyContent) {
             Http3DataFrame dataFrame = ch.readOutbound();
-            assertThat(dataFrame.content().readableBytes(), is(1));
+            assertEquals(1, dataFrame.content().readableBytes());
             dataFrame.release();
         }
         if (hasTrailers) {
             Http3HeadersFrame trailersFrame = ch.readOutbound();
-            assertThat(trailersFrame.headers().get("foo"), is("bar"));
+            assertEquals("bar", trailersFrame.headers().get("foo"));
         } else if (!nonEmptyContent && !headers) {
             Http3DataFrame dataFrame = ch.readOutbound();
-            assertThat(dataFrame.content().readableBytes(), is(0));
+            assertEquals(0, dataFrame.content().readableBytes());
             dataFrame.release();
         }
 
@@ -841,13 +838,13 @@ data.release();
 
         final FullHttpResponse response = ch.readInbound();
         try {
-            assertThat(response.status(), is(HttpResponseStatus.CONTINUE));
-            assertThat(response.protocolVersion(), is(HttpVersion.HTTP_1_1));
+            assertEquals(HttpResponseStatus.CONTINUE, response.status());
+            assertEquals(HttpVersion.HTTP_1_1, response.protocolVersion());
         } finally {
             response.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -861,12 +858,12 @@ data.release();
         assertTrue(ch.writeInbound(new DefaultHttp3HeadersFrame(headers)));
 
         HttpResponse response = ch.readInbound();
-        assertThat(response.status(), is(HttpResponseStatus.OK));
-        assertThat(response.protocolVersion(), is(HttpVersion.HTTP_1_1));
-        assertFalse(response instanceof FullHttpResponse);
+        assertEquals(HttpResponseStatus.OK, response.status());
+        assertEquals(HttpVersion.HTTP_1_1, response.protocolVersion());
+        assertThat(response).isNotInstanceOf(FullHttpResponse.class);
         assertTrue(HttpUtil.isTransferEncodingChunked(response));
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -881,12 +878,12 @@ data.release();
         assertTrue(ch.writeInbound(new DefaultHttp3HeadersFrame(headers)));
 
         HttpResponse response = ch.readInbound();
-        assertThat(response.status(), is(HttpResponseStatus.OK));
-        assertThat(response.protocolVersion(), is(HttpVersion.HTTP_1_1));
-        assertFalse(response instanceof FullHttpResponse);
+        assertEquals(HttpResponseStatus.OK, response.status());
+        assertEquals(HttpVersion.HTTP_1_1, response.protocolVersion());
+        assertThat(response).isNotInstanceOf(FullHttpResponse.class);
         assertFalse(HttpUtil.isTransferEncodingChunked(response));
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -899,14 +896,14 @@ data.release();
 
         LastHttpContent trailers = ch.readInbound();
         try {
-            assertThat(trailers.content().readableBytes(), is(0));
-            assertThat(trailers.trailingHeaders().get("key"), is("value"));
-            assertFalse(trailers instanceof FullHttpRequest);
+            assertEquals(0, trailers.content().readableBytes());
+            assertEquals("value", trailers.trailingHeaders().get("key"));
+            assertThat(trailers).isNotInstanceOf(FullHttpRequest.class);
         } finally {
             trailers.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -918,13 +915,13 @@ data.release();
 
         HttpContent content = ch.readInbound();
         try {
-            assertThat(content.content().toString(CharsetUtil.UTF_8), is("hello world"));
-            assertFalse(content instanceof LastHttpContent);
+            assertEquals("hello world", content.content().toString(CharsetUtil.UTF_8));
+            assertThat(content).isNotInstanceOf(LastHttpContent.class);
         } finally {
             content.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -936,7 +933,7 @@ data.release();
 
         HttpContent content = ch.readInbound();
         try {
-            assertThat(content.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", content.content().toString(CharsetUtil.UTF_8));
         } finally {
             content.release();
         }
@@ -949,7 +946,7 @@ data.release();
             last.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -963,8 +960,8 @@ data.release();
         Http3HeadersFrame headersFrame = ch.readOutbound();
         Http3Headers headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("https"));
-        assertThat(headers.authority().toString(), is("example.com"));
+        assertEquals("https", headers.scheme().toString());
+        assertEquals("example.com", headers.authority().toString());
         assertTrue(ch.isOutputShutdown());
 
         assertFalse(ch.finish());
@@ -1060,16 +1057,16 @@ data.release();
             stream.writeAndFlush(request);
 
             HttpResponse respHeaders = (HttpResponse) received.poll(20, TimeUnit.SECONDS);
-            assertThat(respHeaders, notNullValue());
-            assertThat(respHeaders.status(), is(HttpResponseStatus.OK));
-            assertThat(respHeaders, not(instanceOf(LastHttpContent.class)));
+            assertNotNull(respHeaders);
+            assertEquals(HttpResponseStatus.OK, respHeaders.status());
+            assertThat(respHeaders).isNotInstanceOf(LastHttpContent.class);
             HttpContent respBody = (HttpContent) received.poll(20, TimeUnit.SECONDS);
-            assertThat(respBody, notNullValue());
-            assertThat(respBody.content().toString(CharsetUtil.UTF_8), is("foo"));
+            assertNotNull(respBody);
+            assertEquals("foo", respBody.content().toString(CharsetUtil.UTF_8));
             respBody.release();
 
             LastHttpContent last = (LastHttpContent) received.poll(20, TimeUnit.SECONDS);
-            assertThat(last, notNullValue());
+            assertNotNull(last);
             last.release();
         } finally {
             group.shutdownGracefully();

--- a/src/test/java/io/netty/incubator/codec/http3/Http3TestUtils.java
+++ b/src/test/java/io/netty/incubator/codec/http3/Http3TestUtils.java
@@ -18,10 +18,8 @@ package io.netty.incubator.codec.http3;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 final class Http3TestUtils {
@@ -29,7 +27,7 @@ final class Http3TestUtils {
     private Http3TestUtils() { }
 
     static void assertException(Http3ErrorCode code, Throwable e) {
-        MatcherAssert.assertThat(e, CoreMatchers.instanceOf(Http3Exception.class));
+        assertInstanceOf(Http3Exception.class, e);
         Http3Exception exception = (Http3Exception) e;
         assertEquals(code, exception.errorCode());
     }

--- a/src/test/java/io/netty/incubator/codec/http3/QpackDecoderHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackDecoderHandlerTest.java
@@ -26,10 +26,9 @@ import static io.netty.incubator.codec.http3.Http3.setQpackAttributes;
 import static io.netty.incubator.codec.http3.Http3ErrorCode.QPACK_DECODER_STREAM_ERROR;
 import static io.netty.incubator.codec.http3.Http3SettingsFrame.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY;
 import static io.netty.incubator.codec.http3.QpackUtil.encodePrefixedInteger;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class QpackDecoderHandlerTest {
@@ -54,7 +53,7 @@ public class QpackDecoderHandlerTest {
         encodeHeaders(headers -> headers.add(fooBar.name, fooBar.value));
 
         Http3Exception e = assertThrows(Http3Exception.class, () -> sendAckForStreamId(decoderStream.streamId()));
-        assertThat(e.getCause(), instanceOf(QpackException.class));
+        assertInstanceOf(QpackException.class, e.getCause());
 
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
         finishStreams();
@@ -83,7 +82,7 @@ public class QpackDecoderHandlerTest {
         setup(128);
 
         Http3Exception e = assertThrows(Http3Exception.class, () -> sendAckForStreamId(1));
-        assertThat(e.getCause(), instanceOf(QpackException.class));
+        assertInstanceOf(QpackException.class, e.getCause());
 
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
         finishStreams();
@@ -99,7 +98,7 @@ public class QpackDecoderHandlerTest {
         sendAckForStreamId(decoderStream.streamId());
 
         Http3Exception e = assertThrows(Http3Exception.class, () -> sendAckForStreamId(decoderStream.streamId()));
-        assertThat(e.getCause(), instanceOf(QpackException.class));
+        assertInstanceOf(QpackException.class, e.getCause());
 
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
         finishStreams();
@@ -155,7 +154,7 @@ public class QpackDecoderHandlerTest {
         sendStreamCancellation(decoderStream.streamId());
 
         Http3Exception e = assertThrows(Http3Exception.class, () -> sendAckForStreamId(decoderStream.streamId()));
-        assertThat(e.getCause(), instanceOf(QpackException.class));
+        assertInstanceOf(QpackException.class, e.getCause());
 
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
         finishStreams();
@@ -256,7 +255,7 @@ public class QpackDecoderHandlerTest {
     public void invalidIncrement() throws Exception {
         setup(128);
         Http3Exception e = assertThrows(Http3Exception.class, () -> sendInsertCountIncrement(2));
-        assertThat(e.getCause(), instanceOf(QpackException.class));
+        assertInstanceOf(QpackException.class, e.getCause());
 
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
         finishStreams();
@@ -341,19 +340,19 @@ public class QpackDecoderHandlerTest {
     }
 
     private void finishStreams(boolean encoderPendingMessage) {
-        assertThat("Unexpected decoder stream message", decoderStream.finishAndReleaseAll(), is(false));
-        assertThat("Unexpected encoder stream message", encoderStream.finishAndReleaseAll(), is(encoderPendingMessage));
-        assertThat("Unexpected parent stream message", parent.finishAndReleaseAll(), is(false));
+        assertFalse(decoderStream.finishAndReleaseAll(), "Unexpected decoder stream message");
+        assertEquals(encoderPendingMessage, encoderStream.finishAndReleaseAll(),  "Unexpected encoder stream message");
+        assertFalse(parent.finishAndReleaseAll(), "Unexpected parent stream message");
     }
 
     private void verifyRequiredInsertCount(int insertCount) {
-        assertThat("Unexpected dynamic table insert count.",
+        assertEquals(insertCount == 0 ? 0 : insertCount % maxEntries + 1,
                 dynamicTable.encodedRequiredInsertCount(dynamicTable.insertCount()),
-                is(insertCount == 0 ? 0 : insertCount % maxEntries + 1));
+                "Unexpected dynamic table insert count.");
     }
 
     private void verifyKnownReceivedCount(int receivedCount) {
-        assertThat("Unexpected dynamic table known received count.", dynamicTable.encodedKnownReceivedCount(),
-                is(receivedCount == 0 ? 0 : receivedCount % maxEntries + 1));
+        assertEquals(receivedCount == 0 ? 0 : receivedCount % maxEntries + 1, dynamicTable.encodedKnownReceivedCount(),
+                "Unexpected dynamic table known received count.");
     }
 }

--- a/src/test/java/io/netty/incubator/codec/http3/QpackDecoderTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackDecoderTest.java
@@ -28,8 +28,7 @@ import static io.netty.incubator.codec.http3.QpackDecoderStateSyncStrategy.ackEa
 import static io.netty.incubator.codec.http3.QpackUtil.MAX_UNSIGNED_INT;
 import static java.lang.Math.toIntExact;
 import static java.util.Arrays.asList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class QpackDecoderTest {
@@ -131,7 +130,7 @@ public class QpackDecoderTest {
 
     private void encodeDecodeVerifyRequiredInsertCount(int count) throws QpackException {
         final int ric = encodeDecodeRequiredInsertCount(count);
-        assertThat(ric, is(count));
+        assertEquals(count, ric);
     }
 
     private int encodeDecodeDeltaBase(int requiredInsertCount, boolean postBase, int deltaBase) throws QpackException {
@@ -159,11 +158,11 @@ public class QpackDecoderTest {
             inserted++;
             decoder.insertLiteral(decoderStream, FOO + i, BAR + i);
         }
-        assertThat(decoderStream.finishAndReleaseAll(), is(count > 0));
+        assertEquals(count > 0, decoderStream.finishAndReleaseAll());
     }
 
     private void verifyField(QpackHeaderField field, int fieldIndexWhenInserted) {
-        assertThat(field.name, is(FOO + fieldIndexWhenInserted));
-        assertThat(field.value, is(BAR + fieldIndexWhenInserted));
+        assertEquals(FOO + fieldIndexWhenInserted, field.name);
+        assertEquals(BAR + fieldIndexWhenInserted, field.value);
     }
 }

--- a/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDecoderTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDecoderTest.java
@@ -34,11 +34,12 @@ import static io.netty.buffer.UnpooledByteBufAllocator.DEFAULT;
 import static io.netty.incubator.codec.http3.Http3SettingsFrame.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS;
 import static io.netty.incubator.codec.http3.Http3SettingsFrame.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY;
 import static io.netty.incubator.codec.quic.QuicStreamType.UNIDIRECTIONAL;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -133,8 +134,8 @@ public class QpackEncoderDecoderTest {
         verifyRequiredInsertCount(3);
         verifyKnownReceivedCount(3);
         decode(out, decHeaders);
-        assertThat(decDynamicTable.insertCount(), is(3));
-        assertThat(decHeaders.size(), is(3));
+        assertEquals(3, decDynamicTable.insertCount());
+        assertEquals(3, decHeaders.size());
         verifyDecodedHeaders("foo", "bar", 3);
 
         resetState();
@@ -143,8 +144,8 @@ public class QpackEncoderDecoderTest {
         verifyRequiredInsertCount(6);
         verifyKnownReceivedCount(6);
         decode(out, decHeaders);
-        assertThat(decDynamicTable.insertCount(), is(6));
-        assertThat(decHeaders.size(), is(3));
+        assertEquals(6, decDynamicTable.insertCount());
+        assertEquals(3, decHeaders.size());
         verifyDecodedHeaders("boo", "far", 3);
 
         resetState();
@@ -154,24 +155,22 @@ public class QpackEncoderDecoderTest {
         verifyKnownReceivedCount(9);
 
         decode(out, decHeaders);
-        assertThat(decDynamicTable.insertCount(), is(9));
-        assertThat(decHeaders.size(), is(3));
+        assertEquals(9, decDynamicTable.insertCount());
+        assertEquals(3, decHeaders.size());
         verifyDecodedHeaders("zoo", "gar", 3);
 
         // Now reuse the headers for encode to use dynamic table.
         resetState();
-        assertThat("Header not found in encoder dynamic table.",
-                encDynamicTable.getEntryIndex("zoo1", "gar"), greaterThanOrEqualTo(0));
-        assertThat("Header not found in encoder dynamic table.",
-                encDynamicTable.getEntryIndex("zoo2", "gar"), greaterThanOrEqualTo(0));
+        assertThat(encDynamicTable.getEntryIndex("zoo1", "gar")).isGreaterThanOrEqualTo(0);
+        assertThat(encDynamicTable.getEntryIndex("zoo2", "gar")).isGreaterThanOrEqualTo(0);
         encHeaders.add("zoo1", "gar");
         encHeaders.add("zoo2", "gar");
         encode(out, encHeaders);
         verifyRequiredInsertCount(9); // No new inserts
         verifyKnownReceivedCount(9); // No new inserts
         decode(out, decHeaders);
-        assertThat(decDynamicTable.insertCount(), is(9));
-        assertThat(decHeaders.size(), is(2));
+        assertEquals(9, decDynamicTable.insertCount());
+        assertEquals(2, decHeaders.size());
         verifyDecodedHeader("zoo1", "gar");
         verifyDecodedHeader("zoo2", "gar");
     }
@@ -184,14 +183,14 @@ public class QpackEncoderDecoderTest {
         encode(out, encHeaders);
         verifyRequiredInsertCount(3);
         verifyKnownReceivedCount(0);
-        assertThat(decDynamicTable.insertCount(), is(0));
+        assertEquals(0, decDynamicTable.insertCount());
 
         drainNextSuspendedEncoderInstruction();
         decode(out, decHeaders);
         drainAllSuspendedEncoderInstructions();
-        assertThat(decDynamicTable.insertCount(), is(3));
+        assertEquals(3, decDynamicTable.insertCount());
         verifyKnownReceivedCount(3);
-        assertThat(decHeaders.size(), is(3));
+        assertEquals(3, decHeaders.size());
         verifyDecodedHeaders("foo", "bar", 3);
 
         resetState();
@@ -202,9 +201,9 @@ public class QpackEncoderDecoderTest {
 
         decode(out, decHeaders);
         drainAllSuspendedEncoderInstructions();
-        assertThat(decDynamicTable.insertCount(), is(6));
+        assertEquals(6, decDynamicTable.insertCount());
         verifyKnownReceivedCount(6);
-        assertThat(decHeaders.size(), is(3));
+        assertEquals(3, decHeaders.size());
         verifyDecodedHeaders("boo", "far", 3);
 
         resetState();
@@ -216,24 +215,22 @@ public class QpackEncoderDecoderTest {
         decode(out, decHeaders);
         drainAllSuspendedEncoderInstructions();
         verifyKnownReceivedCount(9);
-        assertThat(decDynamicTable.insertCount(), is(9));
-        assertThat(decHeaders.size(), is(3));
+        assertEquals(9, decDynamicTable.insertCount());
+        assertEquals(3, decHeaders.size());
         verifyDecodedHeaders("zoo", "gar", 3);
 
         // Now reuse the headers for encode to use dynamic table.
         resetState();
-        assertThat("Header not found in encoder dynamic table.",
-                encDynamicTable.getEntryIndex("zoo1", "gar"), greaterThanOrEqualTo(0));
-        assertThat("Header not found in encoder dynamic table.",
-                encDynamicTable.getEntryIndex("zoo2", "gar"), greaterThanOrEqualTo(0));
+        assertThat(encDynamicTable.getEntryIndex("zoo1", "gar")).isGreaterThanOrEqualTo(0);
+        assertThat(encDynamicTable.getEntryIndex("zoo2", "gar")).isGreaterThanOrEqualTo(0);
         encHeaders.add("zoo1", "gar");
         encHeaders.add("zoo2", "gar");
         encode(out, encHeaders);
         verifyRequiredInsertCount(9); // No new inserts
         verifyKnownReceivedCount(9); // No new inserts
         decode(out, decHeaders);
-        assertThat(decDynamicTable.insertCount(), is(9));
-        assertThat(decHeaders.size(), is(2));
+        assertEquals(9, decDynamicTable.insertCount());
+        assertEquals(2, decHeaders.size());
         verifyDecodedHeader("zoo1", "gar");
         verifyDecodedHeader("zoo2", "gar");
     }
@@ -247,7 +244,7 @@ public class QpackEncoderDecoderTest {
 
         addEncodeHeader("foo", "bar", 5);
         QpackHeaderField oldEntry = new QpackHeaderField("foo0", "bar");
-        assertThat(encHeaders.get(oldEntry.name, oldEntry.value), is(notNullValue()));
+        assertNotNull(encHeaders.get(oldEntry.name, oldEntry.value));
 
         ByteBuf spareEncode = Unpooled.buffer();
         try {
@@ -259,8 +256,8 @@ public class QpackEncoderDecoderTest {
         verifyKnownReceivedCount(0);
 
         final int idx = encDynamicTable.getEntryIndex(oldEntry.name, oldEntry.value);
-        assertThat(idx, greaterThanOrEqualTo(0));
-        assertThat(encDynamicTable.requiresDuplication(idx, oldEntry.size()), is(true));
+        assertThat(idx).isGreaterThanOrEqualTo(0);
+        assertTrue(encDynamicTable.requiresDuplication(idx, oldEntry.size()));
 
         resetState();
         stateSyncStrategyAckNextInsert = true;
@@ -271,8 +268,8 @@ public class QpackEncoderDecoderTest {
         decode(out, decHeaders);
         verifyKnownReceivedCount(6);
 
-        assertThat(decDynamicTable.insertCount(), is(6));
-        assertThat(decHeaders.size(), is(1));
+        assertEquals(6, decDynamicTable.insertCount());
+        assertEquals(1, decHeaders.size());
         verifyDecodedHeader(oldEntry.name, oldEntry.value);
 
         // Now encode again to refer to the duplicated entry
@@ -284,8 +281,8 @@ public class QpackEncoderDecoderTest {
         decode(out, decHeaders);
         verifyKnownReceivedCount(6);
 
-        assertThat(decDynamicTable.insertCount(), is(6));
-        assertThat(decHeaders.size(), is(1));
+        assertEquals(6, decDynamicTable.insertCount());
+        assertEquals(1, decHeaders.size());
         verifyDecodedHeader(oldEntry.name, oldEntry.value);
     }
 
@@ -298,7 +295,7 @@ public class QpackEncoderDecoderTest {
 
         addEncodeHeader("foo", "bar", 5);
         QpackHeaderField oldEntry = new QpackHeaderField("foo0", "bar");
-        assertThat(encHeaders.get(oldEntry.name, oldEntry.value), is(notNullValue()));
+        assertNotNull(encHeaders.get(oldEntry.name, oldEntry.value));
 
         ByteBuf spareEncode = Unpooled.buffer();
         try {
@@ -310,8 +307,8 @@ public class QpackEncoderDecoderTest {
         verifyKnownReceivedCount(0);
 
         final int idx = encDynamicTable.getEntryIndex(oldEntry.name, oldEntry.value);
-        assertThat(idx, greaterThanOrEqualTo(0));
-        assertThat(encDynamicTable.requiresDuplication(idx, oldEntry.size()), is(true));
+        assertThat(idx).isGreaterThanOrEqualTo(0);
+        assertTrue(encDynamicTable.requiresDuplication(idx, oldEntry.size()));
 
         resetState();
         stateSyncStrategyAckNextInsert = true;
@@ -322,13 +319,13 @@ public class QpackEncoderDecoderTest {
 
         drainNextSuspendedEncoderInstruction();
         decode(out, decHeaders);
-        assertThat(decDynamicTable.insertCount(), is(0));
+        assertEquals(0, decDynamicTable.insertCount());
         verifyKnownReceivedCount(0);
 
         drainAllSuspendedEncoderInstructions();
-        assertThat(decDynamicTable.insertCount(), is(6));
+        assertEquals(6, decDynamicTable.insertCount());
         verifyKnownReceivedCount(6);
-        assertThat(decHeaders.size(), is(1));
+        assertEquals(1, decHeaders.size());
         verifyDecodedHeader(oldEntry.name, oldEntry.value);
     }
 
@@ -339,8 +336,8 @@ public class QpackEncoderDecoderTest {
         verifyKnownReceivedCount(headersAdded);
 
         decode(out, decHeaders);
-        assertThat(decDynamicTable.insertCount(), is(headersAdded));
-        assertThat(decHeaders.size(), is(1));
+        assertEquals(headersAdded, decDynamicTable.insertCount());
+        assertEquals(1, decHeaders.size());
         verifyDecodedHeader(name, value);
 
         // Encode again to refer to dynamic table
@@ -352,8 +349,8 @@ public class QpackEncoderDecoderTest {
         verifyKnownReceivedCount(headersAdded);
 
         decode(out, decHeaders);
-        assertThat(decDynamicTable.insertCount(), is(headersAdded));
-        assertThat(decHeaders.size(), is(1));
+        assertEquals(headersAdded, decDynamicTable.insertCount());
+        assertEquals(1, decHeaders.size());
         verifyDecodedHeader(name, value);
     }
 
@@ -363,16 +360,16 @@ public class QpackEncoderDecoderTest {
         verifyRequiredInsertCount(headersAdded);
 
         verifyKnownReceivedCount(headersAdded - 1);
-        assertThat(decDynamicTable.insertCount(), is(headersAdded - 1));
+        assertEquals(headersAdded - 1, decDynamicTable.insertCount());
 
         drainNextSuspendedEncoderInstruction();
 
         decode(out, decHeaders);
         drainAllSuspendedEncoderInstructions();
-        assertThat(decDynamicTable.insertCount(), is(headersAdded));
+        assertEquals(headersAdded, decDynamicTable.insertCount());
         verifyKnownReceivedCount(headersAdded);
 
-        assertThat(decHeaders.size(), is(1));
+        assertEquals(1, decHeaders.size());
         verifyDecodedHeader(name, value);
     }
 
@@ -389,7 +386,7 @@ public class QpackEncoderDecoderTest {
         encode(out, encHeaders);
         decode(out, decHeaders);
 
-        assertThat(decHeaders.size(), is(5));
+        assertEquals(5, decHeaders.size());
         verifyDecodedHeader(":authority", "netty.quic");
         verifyDecodedHeader(":path", "/");
         verifyDecodedHeader(":method", "GET");
@@ -417,7 +414,7 @@ public class QpackEncoderDecoderTest {
 
     private void encode(ByteBuf buf, Http3Headers headers) {
         encoder.encodeHeaders(attributes, buf, DEFAULT, 1, headers);
-        assertThat("Parent channel closed.", parent.isActive(), is(true));
+        assertTrue(parent.isActive());
     }
 
     private void decode(ByteBuf buf, Http3Headers headers) throws QpackException {
@@ -433,11 +430,11 @@ public class QpackEncoderDecoderTest {
                         throw new AssertionError("Decode failed.", e);
                     }
                 });
-        assertThat("Parent channel closed.", parent.isActive(), is(true));
+        assertTrue(parent.isActive());
     }
 
     private void verifyDecodedHeader(CharSequence name, CharSequence value) {
-        assertThat(decHeaders.get(name), is(new AsciiString(value)));
+        assertEquals(new AsciiString(value), decHeaders.get(name));
     }
 
     private void drainAllSuspendedEncoderInstructions() throws Exception {
@@ -449,7 +446,7 @@ public class QpackEncoderDecoderTest {
 
     private void drainNextSuspendedEncoderInstruction() throws Exception {
         Callable<Void> next = suspendedEncoderInstructions.poll();
-        assertThat(next, is(notNullValue())); // dynamic table size instruction
+        assertNotNull(next); // dynamic table size instruction
         next.call();
     }
 
@@ -499,14 +496,14 @@ public class QpackEncoderDecoderTest {
     }
 
     private void verifyRequiredInsertCount(int insertCount) {
-        assertThat("Unexpected dynamic table insert count.",
+        assertEquals(insertCount == 0 ? 0 : insertCount % (2 * maxEntries) + 1,
                 encDynamicTable.encodedRequiredInsertCount(encDynamicTable.insertCount()),
-                is(insertCount == 0 ? 0 : insertCount % (2 * maxEntries) + 1));
+                "Unexpected dynamic table insert count.");
     }
 
     private void verifyKnownReceivedCount(int receivedCount) {
-        assertThat("Unexpected dynamic table known received count.", encDynamicTable.encodedKnownReceivedCount(),
-                is(receivedCount == 0 ? 0 : receivedCount % (2 * maxEntries) + 1));
+        assertEquals(receivedCount == 0 ? 0 : receivedCount % (2 * maxEntries) + 1,
+                encDynamicTable.encodedKnownReceivedCount(), "Unexpected dynamic table known received count.");
     }
 
     private static final class ForwardWriteToReadOnOtherHandler extends ChannelOutboundHandlerAdapter {

--- a/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDynamicTableTest.java
+++ b/src/test/java/io/netty/incubator/codec/http3/QpackEncoderDynamicTableTest.java
@@ -19,10 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.netty.incubator.codec.http3.QpackUtil.MAX_HEADER_TABLE_SIZE;
 import static java.lang.Math.toIntExact;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThan;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -39,8 +36,7 @@ public class QpackEncoderDynamicTableTest {
     public void zeroCapacityIsAllowed() throws Exception {
         QpackEncoderDynamicTable table = newDynamicTable(0);
 
-        assertThat("Header addition passed.", addHeader(table, emptyHeader),
-                lessThan(0));
+        assertThat(addHeader(table, emptyHeader)).isLessThan(0);
     }
 
     @Test
@@ -67,16 +63,16 @@ public class QpackEncoderDynamicTableTest {
         addAndValidateHeader(table, fooBarHeader);
         final int idx2 = addAndValidateHeader(table, fooBar2Header);
 
-        assertThat("Header addition passed.", addHeader(table, fooBarHeader), lessThan(0));
+        assertThat(addHeader(table, fooBarHeader)).isLessThan(0);
 
         table.incrementKnownReceivedCount(3);
-        assertThat("Unexpected entry index.", getEntryIndex(table, emptyHeader), lessThan(0));
-        assertThat("Unexpected entry index.", getEntryIndex(table, fooBarHeader), lessThan(0));
-        assertThat("Unexpected entry index.", getEntryIndex(table, fooBar2Header), is(idx2));
+        assertThat(getEntryIndex(table, emptyHeader)).isLessThan(0);
+        assertThat(getEntryIndex(table, fooBarHeader)).isLessThan(0);
+        assertEquals(idx2, getEntryIndex(table, fooBar2Header));
 
         final int idx1 = addAndValidateHeader(table, emptyHeader);
-        assertThat("Unexpected entry index.", getEntryIndex(table, emptyHeader), is(idx1));
-        assertThat("Unexpected entry index.", getEntryIndex(table, fooBar2Header), lessThan(0));
+        assertEquals(idx1, getEntryIndex(table, emptyHeader));
+        assertThat(getEntryIndex(table, fooBar2Header)).isLessThan(0);
     }
 
     @Test
@@ -85,13 +81,12 @@ public class QpackEncoderDynamicTableTest {
 
         final int idx1 = addValidateAndAckHeader(table, emptyHeader);
         assertEquals(0, idx1);
-        assertThat("Unexpected entry index.", getEntryIndex(table, emptyHeader), is(idx1));
+        assertEquals(idx1, getEntryIndex(table, emptyHeader));
 
         final int idx2 = addValidateAndAckHeader(table, fooBarHeader);
         assertEquals(1, idx2);
-        assertThat("Unexpected entry index.", getEntryIndex(table, fooBarHeader), is(idx2));
-
-        assertThat("Unexpected entry index.", getEntryIndex(table, emptyHeader), is(idx1));
+        assertEquals(idx2, getEntryIndex(table, fooBarHeader));
+        assertEquals(idx1, getEntryIndex(table, emptyHeader));
     }
 
     @Test
@@ -101,8 +96,8 @@ public class QpackEncoderDynamicTableTest {
         final int lastIdx = addValidateAndAckHeader(table, fooBar2Header);
 
         final int idx = table.getEntryIndex("foo", "baz");
-        assertThat("Unexpected index.", idx, lessThan(0));
-        assertThat("Unexpected index.", idx, is(-lastIdx - 1));
+        assertThat(idx).isLessThan(0);
+        assertEquals(-lastIdx - 1, idx);
     }
 
     @Test
@@ -110,14 +105,14 @@ public class QpackEncoderDynamicTableTest {
         QpackEncoderDynamicTable table = newDynamicTable(128);
 
         final int idx1 = addValidateAndAckHeader(table, emptyHeader);
-        assertThat("Unexpected entry index.", getEntryIndex(table, emptyHeader), is(idx1));
+        assertEquals(idx1, getEntryIndex(table, emptyHeader));
 
         final int idx2 = addValidateAndAckHeader(table, fooBarHeader);
-        assertThat("Unexpected entry index.", getEntryIndex(table, fooBarHeader), is(idx2));
+        assertEquals(idx2, getEntryIndex(table, fooBarHeader));
 
         final int idx3 = addValidateAndAckHeader(table, emptyHeader);
         // Return the most recent entry
-        assertThat("Unexpected entry index.", getEntryIndex(table, emptyHeader), is(idx3));
+        assertEquals(idx3, getEntryIndex(table, emptyHeader));
     }
 
     @Test
@@ -129,9 +124,9 @@ public class QpackEncoderDynamicTableTest {
 
         addValidateAndAckHeader(table, fooBar3Header); // size = 116, exceeds max threshold, should evict eldest
 
-        assertThat("Entry found.", getEntryIndex(table, fooBarHeader), lessThan(0));
-        assertThat("Entry not found.", getEntryIndex(table, fooBar2Header), greaterThanOrEqualTo(0));
-        assertThat("Entry not found.", getEntryIndex(table, fooBar3Header), greaterThanOrEqualTo(0));
+        assertThat(getEntryIndex(table, fooBarHeader)).isLessThan(0);
+        assertThat(getEntryIndex(table, fooBar2Header)).isGreaterThanOrEqualTo(0);
+        assertThat(getEntryIndex(table, fooBar3Header)).isGreaterThanOrEqualTo(0);
     }
 
     @Test
@@ -163,7 +158,7 @@ public class QpackEncoderDynamicTableTest {
         table.addReferenceToEntry(fooBarHeader.name, fooBarHeader.value, idx);
         table.acknowledgeInsertCountOnAck(idx);
 
-        assertThat("Unexpected known received count.", table.encodedKnownReceivedCount(), is(2));
+        assertEquals(2, table.encodedKnownReceivedCount());
     }
 
     @Test
@@ -177,10 +172,10 @@ public class QpackEncoderDynamicTableTest {
         table.addReferenceToEntry(fooBarHeader.name, fooBarHeader.value, idx2);
 
         table.acknowledgeInsertCountOnAck(idx2);
-        assertThat("Unexpected known received count.", table.encodedKnownReceivedCount(), is(3));
+        assertEquals(3, table.encodedKnownReceivedCount());
 
         table.acknowledgeInsertCountOnAck(idx1);
-        assertThat("Unexpected known received count.", table.encodedKnownReceivedCount(), is(3)); // already acked
+        assertEquals(3, table.encodedKnownReceivedCount()); // already acked
     }
 
     @Test
@@ -195,7 +190,7 @@ public class QpackEncoderDynamicTableTest {
         table.acknowledgeInsertCountOnAck(idx1);
 
         // first entry still active
-        assertThat("Header added", addHeader(table, fooBar2Header), lessThan(0));
+        assertThat(addHeader(table, fooBar2Header)).isLessThan(0);
 
         table.acknowledgeInsertCountOnAck(idx1);
         verifyTableEmpty(table);
@@ -203,7 +198,7 @@ public class QpackEncoderDynamicTableTest {
     }
 
     private void verifyTableEmpty(QpackEncoderDynamicTable table) {
-        assertThat(table.insertCount(), is(0));
+        assertEquals(0, table.insertCount());
         insertCount = 0;
     }
 
@@ -221,7 +216,7 @@ public class QpackEncoderDynamicTableTest {
 
     private int addAndValidateHeader(QpackEncoderDynamicTable table, QpackHeaderField header) {
         final int addedIdx = addHeader(table, header);
-        assertThat("Header addition failed.", addedIdx, greaterThanOrEqualTo(0));
+        assertThat(addedIdx).isGreaterThanOrEqualTo(0);
         verifyInsertCount(table);
         return addedIdx;
     }
@@ -251,8 +246,8 @@ public class QpackEncoderDynamicTableTest {
     }
 
     private void verifyInsertCount(QpackEncoderDynamicTable table) {
-        assertThat("Unexpected required insert count.",
-                table.encodedRequiredInsertCount(table.insertCount()), is(expectedInsertCount()));
+        assertEquals(expectedInsertCount(), table.encodedRequiredInsertCount(table.insertCount()),
+                "Unexpected required insert count.");
     }
 
     private int expectedInsertCount() {


### PR DESCRIPTION
Motivation:

We use assert4j in all our projects these days, let's do the same here

Modifications:

Replace usage of hamcrest with assert4j

Result:

Cleanup