### PR TITLE
Update to last quic release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <skipTests>false</skipTests>
     <netty.version>4.1.122.Final</netty.version>
     <netty.build.version>31</netty.build.version>
-    <netty.quic.version>0.0.72.Final</netty.quic.version>
+    <netty.quic.version>0.0.73.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <junit.version>5.9.0</junit.version>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

We just released a new version of our quic codec.

Modifications:

Update to 0.0.73.Final

Result:

Use latest quic release