### PR TITLE
Update to latest netty-incubator-codec-quic release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <skipTests>false</skipTests>
     <netty.version>4.1.124.Final</netty.version>
     <netty.build.version>31</netty.build.version>
-    <netty.quic.version>0.0.73.Final</netty.quic.version>
+    <netty.quic.version>0.0.74.Final</netty.quic.version>
     <netty.quic.classifier>${os.detected.name}-${os.detected.arch}</netty.quic.classifier>
     <junit.version>5.9.0</junit.version>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

We should use the latest release

Modifications:

Update to 0.0.74.Final

Result:

Depend on the latest quic release