### PR TITLE
bug: application to crash at runtime

### DIFF
--- a/src/test/java/io/netty/incubator/codec/http3/example/Http3ClientExample.java
+++ b/src/test/java/io/netty/incubator/codec/http3/example/Http3ClientExample.java
@@ -51,7 +51,7 @@ public final class Http3ClientExample {
                     .applicationProtocols(Http3.supportedApplicationProtocols()).build();
             ChannelHandler codec = Http3.newQuicClientCodecBuilder()
                     .sslContext(context)
-                    .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
+                    .maxIdleTimeout(100_000_000_000L, TimeUnit.DAYS)
                     .initialMaxData(10000000)
                     .initialMaxStreamDataBidirectionalLocal(1000000)
                     .build();


### PR DESCRIPTION
This branch demonstrates a bug in Netty’s HTTP/3 support.
When maxIdleTimeout is set to an extremely large value (e.g., Long.MAX_VALUE), the application crashes at runtime. The failure originates in the QUIC layer (Rust implementation).


Reproduction
Run the included client example.
The crash occurs automatically. 